### PR TITLE
feat: Add errors offset correction for byte string wrapped CBOR

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -17,7 +17,9 @@ use crate::OperatingHooks;
 #[derive(Clone, Debug)]
 pub(crate) enum CommandArgument<'a> {
     Report(ReportingPolicy),
-    Cbor(Decoder<'a>),
+    // Argument block + offset of the block
+    // We keep offset for error correction
+    Cbor(Decoder<'a>, usize),
 }
 
 impl<'a> CommandArgument<'a> {
@@ -26,8 +28,9 @@ impl<'a> CommandArgument<'a> {
             let policy = d.decode::<ReportingPolicy>()?;
             Ok(CommandArgument::Report(policy))
         } else {
+            let offset = d.position();
             let bytes = d.sub_cbor()?;
-            Ok(CommandArgument::Cbor(Decoder::new(bytes)))
+            Ok(CommandArgument::Cbor(Decoder::new(bytes), offset))
         }
     }
 }
@@ -41,10 +44,18 @@ pub(crate) struct Command<'a> {
 
 impl<'a> Command<'a> {
     fn get_argument_cbor<'b>(&'b mut self) -> Result<&'b mut Decoder<'a>, Error> {
-        if let CommandArgument::Cbor(ref mut decoder) = self.argument {
+        if let CommandArgument::Cbor(ref mut decoder, _) = self.argument {
             return Ok(decoder);
         }
         Err(Error::InvalidCommandSequence(0))
+    }
+
+    fn get_argument_offset(&self) -> usize {
+        if let CommandArgument::Cbor(_, offset) = self.argument {
+            offset
+        } else {
+            0
+        }
     }
 
     fn get_report_policy(&self) -> Result<ReportingPolicy, Error> {
@@ -175,8 +186,10 @@ impl<'a, O: OperatingHooks> CommandSequenceExecutor<'a, O> {
             let mut command = command?;
             if !match_component {
                 if matches!(command.command, SuitCommand::SetComponentIndex) {
-                    if let CommandArgument::Cbor(mut decoder) = command.argument {
-                        match_component = component.in_applylist(&mut decoder)?;
+                    if let CommandArgument::Cbor(mut decoder, arg_offset) = command.argument {
+                        match_component = component
+                            .in_applylist(&mut decoder)
+                            .map_err(|e| e.add_offset(arg_offset))?;
                     }
                 }
             } else {
@@ -186,10 +199,14 @@ impl<'a, O: OperatingHooks> CommandSequenceExecutor<'a, O> {
                     }
                     SuitCommand::Abort => return Err(Error::ConditionMatchFail(command.position)),
                     SuitCommand::OverrideParameters => {
-                        state.update_parameter(command.get_argument_cbor()?)?;
+                        state
+                            .update_parameter(command.get_argument_cbor()?)
+                            .map_err(|e| e.add_offset(command.get_argument_offset()))?;
                     }
                     SuitCommand::SetComponentIndex => {
-                        match_component = component.in_applylist(command.get_argument_cbor()?)?;
+                        match_component = component
+                            .in_applylist(command.get_argument_cbor()?)
+                            .map_err(|e| e.add_offset(command.get_argument_offset()))?;
                     }
                     SuitCommand::CheckContent => {
                         // byte by byte check
@@ -223,7 +240,8 @@ impl<'a, O: OperatingHooks> CommandSequenceExecutor<'a, O> {
                         Err(Error::UnsupportedCommand(SuitCommand::RunSequence.into()))?
                     }
                     SuitCommand::TryEach => {
-                        self.try_each(&mut state, component, command.get_argument_cbor()?)?;
+                        self.try_each(&mut state, component, command.get_argument_cbor()?)
+                            .map_err(|e| e.add_offset(command.get_argument_offset()))?;
                     }
                     SuitCommand::VendorIdentifier => {
                         self.cond_vendor_identifier(&state, component.component())?;
@@ -632,7 +650,7 @@ mod tests {
         let state = ManifestState::default();
         let sequence = CommandSequenceExecutor::new(input.into(), &hooks);
         let res = sequence.process(state.clone(), &info).unwrap_err();
-        assert_eq!(res, Error::TryEachFail(5));
+        assert_eq!(res, Error::TryEachFail(7));
     }
 
     #[test]

--- a/src/command.rs
+++ b/src/command.rs
@@ -17,9 +17,7 @@ use crate::OperatingHooks;
 #[derive(Clone, Debug)]
 pub(crate) enum CommandArgument<'a> {
     Report(ReportingPolicy),
-    // Argument block + offset of the block
-    // We keep offset for error correction
-    Cbor(Decoder<'a>, usize),
+    Cbor { decoder: Decoder<'a>, offset: usize },
 }
 
 impl<'a> CommandArgument<'a> {
@@ -30,7 +28,10 @@ impl<'a> CommandArgument<'a> {
         } else {
             let offset = d.position();
             let bytes = d.sub_cbor()?;
-            Ok(CommandArgument::Cbor(Decoder::new(bytes), offset))
+            Ok(CommandArgument::Cbor {
+                decoder: Decoder::new(bytes),
+                offset,
+            })
         }
     }
 }
@@ -44,14 +45,17 @@ pub(crate) struct Command<'a> {
 
 impl<'a> Command<'a> {
     fn get_argument_cbor<'b>(&'b mut self) -> Result<&'b mut Decoder<'a>, Error> {
-        if let CommandArgument::Cbor(ref mut decoder, _) = self.argument {
+        if let CommandArgument::Cbor {
+            ref mut decoder, ..
+        } = self.argument
+        {
             return Ok(decoder);
         }
         Err(Error::InvalidCommandSequence(0))
     }
 
     fn get_argument_offset(&self) -> usize {
-        if let CommandArgument::Cbor(_, offset) = self.argument {
+        if let CommandArgument::Cbor { offset, .. } = self.argument {
             offset
         } else {
             0
@@ -186,10 +190,14 @@ impl<'a, O: OperatingHooks> CommandSequenceExecutor<'a, O> {
             let mut command = command?;
             if !match_component {
                 if matches!(command.command, SuitCommand::SetComponentIndex) {
-                    if let CommandArgument::Cbor(mut decoder, arg_offset) = command.argument {
+                    if let CommandArgument::Cbor {
+                        ref mut decoder,
+                        offset,
+                    } = command.argument
+                    {
                         match_component = component
-                            .in_applylist(&mut decoder)
-                            .map_err(|e| e.add_offset(arg_offset))?;
+                            .in_applylist(decoder)
+                            .map_err(|e| e.add_offset(offset))?;
                     }
                 }
             } else {

--- a/src/error.rs
+++ b/src/error.rs
@@ -61,6 +61,22 @@ impl Error {
     pub(crate) fn digest_algo_error(value: i64) -> Self {
         Error::UnsupportedDigestAlgo(value)
     }
+
+    /// Use to modify error position on bytes-string wrapped CBOR
+    pub(crate) fn add_offset(self, offset: usize) -> Self {
+        match self {
+            Error::ConditionMatchFail(pos) => Error::ConditionMatchFail(pos + offset),
+            Error::TryEachFail(pos) => Error::TryEachFail(pos + offset),
+            Error::InvalidCommandSequence(pos) => Error::InvalidCommandSequence(pos + offset),
+            Error::ParameterNotSet(pos) => Error::ParameterNotSet(pos + offset),
+            Error::UnexpectedCbor(pos) => Error::UnexpectedCbor(pos + offset),
+            Error::UnexpectedIndefiniteLength(pos) => {
+                Error::UnexpectedIndefiniteLength(pos + offset)
+            }
+            Error::Utf8Error(pos) => Error::Utf8Error(pos + offset),
+            e => e,
+        }
+    }
 }
 
 impl core::fmt::Display for Error {

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -78,32 +78,44 @@ impl<'a> Manifest<'a, Authenticated> {
     fn find_command_sequence(
         &self,
         section: crate::consts::Manifest,
-    ) -> Result<Option<&'a ByteSlice>, Error> {
+    ) -> Result<Option<(&'a ByteSlice, usize)>, Error> {
         let mut decoder = self.decoder.clone();
-        Ok(decoder
-            .map_iter::<i16, Token>()?
-            .find_map(|item| match item {
-                Ok((key, Token::Bytes(value))) if key == section.into() => Some(value.into()),
-                _ => None,
-            }))
+        let len = decoder
+            .map()?
+            .ok_or(Error::UnexpectedCbor(decoder.position()))?;
+        for _ in 0..len {
+            let key = decoder.i16()?;
+            let position = decoder.position();
+            if key == section.into() {
+                let value = decoder.bytes()?;
+                return Ok(Some((value.into(), position)));
+            } else {
+                decoder.skip()?;
+            }
+        }
+        Ok(None)
     }
 
-    fn get_common(&self) -> Result<&'a ByteSlice, Error> {
+    fn get_common(&self) -> Result<(&'a ByteSlice, usize), Error> {
         self.find_command_sequence(crate::consts::Manifest::CommonData)?
             .ok_or(Error::NoCommonSection)
     }
 
     fn component_count(&self) -> Result<usize, Error> {
-        let common_section = self.get_common()?;
+        let (common_section, common_offset) = self.get_common()?;
         let mut decoder = Decoder::new(common_section);
         let len = decoder.map()?.ok_or(Error::InvalidCommonSection)?;
         for _ in 0..len {
             let key = decoder.i16()?;
             if key == crate::consts::SuitCommon::ComponentIdentifiers as i16 {
-                if let Some(num_components) = decoder.array()? {
+                if let Some(num_components) = decoder
+                    .array()
+                    .map_err(|e| Error::from(e).add_offset(common_offset))?
+                {
                     return Ok(num_components as usize);
                 } else {
-                    return Err(Error::UnexpectedIndefiniteLength(decoder.position()));
+                    return Err(Error::UnexpectedIndefiniteLength(decoder.position()))
+                        .map_err(|e| e.add_offset(common_offset));
                 }
             }
         }
@@ -111,10 +123,12 @@ impl<'a> Manifest<'a, Authenticated> {
     }
 
     fn verify_components(&self, os_hooks: &impl OperatingHooks) -> Result<(), Error> {
-        let (components, _) = self.decode_common()?;
+        let (components, _, common_offset) = self.decode_common()?;
         let mut decoder = Decoder::new(components);
-        for component in ComponentIter::new(&mut decoder)? {
-            os_hooks.has_component(&component?)?;
+        for component in
+            ComponentIter::new(&mut decoder).map_err(|e| e.add_offset(common_offset))?
+        {
+            os_hooks.has_component(&component.map_err(|e| e.add_offset(common_offset))?)?;
         }
         Ok(())
     }
@@ -122,14 +136,16 @@ impl<'a> Manifest<'a, Authenticated> {
     fn check_shared_sequence(&self) -> Result<bool, Error> {
         // The shared sequence in the common section must contain a vendor and device class check and
         // is not allowed to contain any custom command
-        let (_, common) = self.decode_common()?;
+        let (_, common, common_offset) = self.decode_common()?;
         let decoder = Decoder::new(common);
-        if !CommandSequenceIterator::new(decoder.clone())?
+        if !CommandSequenceIterator::new(decoder.clone())
+            .map_err(|e| e.add_offset(common_offset))?
             .any(|cmd| cmd.is_ok_and(|c| c.command == SuitCommand::VendorIdentifier))
         {
             return Ok(false);
         }
-        if !CommandSequenceIterator::new(decoder.clone())?
+        if !CommandSequenceIterator::new(decoder.clone())
+            .map_err(|e| e.add_offset(common_offset))?
             .any(|cmd| cmd.is_ok_and(|c| c.command == SuitCommand::ClassIdentifier))
         {
             return Ok(false);
@@ -137,8 +153,8 @@ impl<'a> Manifest<'a, Authenticated> {
         Ok(true)
     }
 
-    fn decode_common(&self) -> Result<(&'a ByteSlice, &'a ByteSlice), Error> {
-        let common_section = self.get_common()?;
+    fn decode_common(&self) -> Result<(&'a ByteSlice, &'a ByteSlice, usize), Error> {
+        let (common_section, common_offset) = self.get_common()?;
         // Only contains the component identifiers and the common command sequence
         let mut decoder = Decoder::new(common_section);
         let mut components = None;
@@ -157,7 +173,7 @@ impl<'a> Manifest<'a, Authenticated> {
             }
         }
         if let (Some(components), Some(commands)) = (components, commands) {
-            Ok((components, commands))
+            Ok((components, commands, common_offset))
         } else {
             Err(Error::InvalidCommonSection)
         }
@@ -198,12 +214,15 @@ impl<'a> Manifest<'a, Authenticated> {
         section: crate::consts::Manifest,
     ) -> Result<(), Error> {
         let start_state = ManifestState::default();
-        let section = self
+        let (section, section_offset) = self
             .find_command_sequence(section)?
             .ok_or(Error::NoCommandSection(section.into()))?;
-        let (components, common) = self.decode_common()?;
+        let (components, common, common_offset) = self.decode_common()?;
         let mut component_decoder = Decoder::new(components);
-        for (idx, component) in ComponentIter::new(&mut component_decoder)?.enumerate() {
+        for (idx, component) in ComponentIter::new(&mut component_decoder)
+            .map_err(|e| e.add_offset(common_offset))?
+            .enumerate()
+        {
             if let Ok(component) = component {
                 let idx = idx
                     .try_into()
@@ -211,9 +230,13 @@ impl<'a> Manifest<'a, Authenticated> {
                 let component_info = ComponentInfo::new(component, idx);
 
                 let common_sequence = CommandSequenceExecutor::new(common, os_hooks);
-                let state = common_sequence.process(start_state.clone(), &component_info)?;
+                let state = common_sequence
+                    .process(start_state.clone(), &component_info)
+                    .map_err(|e| e.add_offset(common_offset))?;
                 let section = CommandSequenceExecutor::new(section, os_hooks);
-                section.process(state, &component_info)?;
+                section
+                    .process(state, &component_info)
+                    .map_err(|e| e.add_offset(section_offset))?;
             }
         }
         Ok(())
@@ -265,7 +288,7 @@ impl<'a> Manifest<'a, Authenticated> {
     /// Execute all command sequences in the manifest.
     pub fn execute_full(&self) -> Result<(), Error> {
         let _state = ManifestState::default();
-        let (_components, _common) = self.decode_common()?;
+        let (_components, _common, _common_offset) = self.decode_common()?;
         // Separate out per component, common first, then the step
         todo!();
         Ok(())

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -73,22 +73,32 @@ impl<'a, S: AuthState> Manifest<'a, S> {
         Ok(seq_no)
     }
 }
+struct Section<'a> {
+    cbor: &'a ByteSlice,
+    offset: usize,
+}
+
+impl<'a> Section<'a> {
+    fn new(cbor: &'a ByteSlice, offset: usize) -> Self {
+        Section { cbor, offset }
+    }
+}
 
 impl<'a> Manifest<'a, Authenticated> {
     fn find_command_sequence(
         &self,
         section: crate::consts::Manifest,
-    ) -> Result<Option<(&'a ByteSlice, usize)>, Error> {
+    ) -> Result<Option<Section<'a>>, Error> {
         let mut decoder = self.decoder.clone();
         let len = decoder
             .map()?
             .ok_or(Error::UnexpectedCbor(decoder.position()))?;
         for _ in 0..len {
             let key = decoder.i16()?;
-            let position = decoder.position();
+            let offset = decoder.position();
             if key == section.into() {
                 let value = decoder.bytes()?;
-                return Ok(Some((value.into(), position)));
+                return Ok(Some(Section::new(value.into(), offset)));
             } else {
                 decoder.skip()?;
             }
@@ -96,26 +106,26 @@ impl<'a> Manifest<'a, Authenticated> {
         Ok(None)
     }
 
-    fn get_common(&self) -> Result<(&'a ByteSlice, usize), Error> {
+    fn get_common(&self) -> Result<Section<'a>, Error> {
         self.find_command_sequence(crate::consts::Manifest::CommonData)?
             .ok_or(Error::NoCommonSection)
     }
 
     fn component_count(&self) -> Result<usize, Error> {
-        let (common_section, common_offset) = self.get_common()?;
-        let mut decoder = Decoder::new(common_section);
+        let common_section = self.get_common()?;
+        let mut decoder = Decoder::new(common_section.cbor);
         let len = decoder.map()?.ok_or(Error::InvalidCommonSection)?;
         for _ in 0..len {
             let key = decoder.i16()?;
             if key == crate::consts::SuitCommon::ComponentIdentifiers as i16 {
                 if let Some(num_components) = decoder
                     .array()
-                    .map_err(|e| Error::from(e).add_offset(common_offset))?
+                    .map_err(|e| Error::from(e).add_offset(common_section.offset))?
                 {
                     return Ok(num_components as usize);
                 } else {
                     return Err(Error::UnexpectedIndefiniteLength(decoder.position()))
-                        .map_err(|e| e.add_offset(common_offset));
+                        .map_err(|e| e.add_offset(common_section.offset));
                 }
             }
         }
@@ -154,9 +164,9 @@ impl<'a> Manifest<'a, Authenticated> {
     }
 
     fn decode_common(&self) -> Result<(&'a ByteSlice, &'a ByteSlice, usize), Error> {
-        let (common_section, common_offset) = self.get_common()?;
+        let common_section = self.get_common()?;
         // Only contains the component identifiers and the common command sequence
-        let mut decoder = Decoder::new(common_section);
+        let mut decoder = Decoder::new(common_section.cbor);
         let mut components = None;
         let mut commands = None;
         let len = decoder.map()?.ok_or(Error::InvalidCommonSection)?;
@@ -173,7 +183,7 @@ impl<'a> Manifest<'a, Authenticated> {
             }
         }
         if let (Some(components), Some(commands)) = (components, commands) {
-            Ok((components, commands, common_offset))
+            Ok((components, commands, common_section.offset))
         } else {
             Err(Error::InvalidCommonSection)
         }
@@ -214,7 +224,7 @@ impl<'a> Manifest<'a, Authenticated> {
         section: crate::consts::Manifest,
     ) -> Result<(), Error> {
         let start_state = ManifestState::default();
-        let (section, section_offset) = self
+        let command_section = self
             .find_command_sequence(section)?
             .ok_or(Error::NoCommandSection(section.into()))?;
         let (components, common, common_offset) = self.decode_common()?;
@@ -233,10 +243,10 @@ impl<'a> Manifest<'a, Authenticated> {
                 let state = common_sequence
                     .process(start_state.clone(), &component_info)
                     .map_err(|e| e.add_offset(common_offset))?;
-                let section = CommandSequenceExecutor::new(section, os_hooks);
+                let section = CommandSequenceExecutor::new(command_section.cbor, os_hooks);
                 section
                     .process(state, &component_info)
-                    .map_err(|e| e.add_offset(section_offset))?;
+                    .map_err(|e| e.add_offset(command_section.offset))?;
             }
         }
         Ok(())


### PR DESCRIPTION
Closes #6

When an error occurs inside a byte-string wrapped CBOR section, the error offset was relative to the start of the byte string rather than the full manifest. This made it difficult to locate the exact position of the failure in the manifest.
Changes:

- Add add_offset method on Error to increment the position of errors that carry a location
- `command.rs` store the offset of each command argument alongside its decoder in CommandArgument::Cbor, and propagate it when errors are returned from update_parameter, in_applylist and try_each
- `manifest.rs`: return the offset alongside the byte slice in find_command_sequence, get_common and decode_common, and propagate it when errors are returned from sub-decoders in `component_count`, `verify_components`, `check_shared_sequence` and `execute_section_with_common`

Notes:
Additional tests covering the offset correction at the manifest level (common section, command sequences) would be valuable but require a full manifest binary fixture. The existing `try_each_fail` test has been updated to verify the corrected offset at the command sequence level.