### PR TITLE
feat: Add support for severable elements (issue #4)

### DIFF
--- a/src/consts.rs
+++ b/src/consts.rs
@@ -33,6 +33,18 @@ pub enum SuitEnvelope {
     Text = 23,
 }
 
+impl TryFrom<Manifest> for SuitEnvelope {
+    type Error = crate::error::Error;
+    fn try_from(value: Manifest) -> Result<Self, Self::Error> {
+        Ok(match value {
+            Manifest::PayloadFetch => SuitEnvelope::PayloadFetch,
+            Manifest::PayloadInstallation => SuitEnvelope::PayloadInstallation,
+            Manifest::TextDescription => SuitEnvelope::Text,
+            _ => return Err(crate::error::Error::NotSeverable(value.into())),
+        })
+    }
+}
+
 /// Manifest elements
 ///
 /// See <https://datatracker.ietf.org/doc/html/draft-ietf-suit-manifest-34#name-suit-manifest-elements>

--- a/src/error.rs
+++ b/src/error.rs
@@ -23,6 +23,8 @@ pub enum Error {
     EndOfInput,
     /// Authentication structure is not valid.
     InvalidAuthenticationStructure,
+    /// SUIT Manifest section is not severable.
+    NotSeverable(i16),
     /// Invalid command sequence.
     InvalidCommandSequence(usize),
     /// Invalid common section.
@@ -102,6 +104,7 @@ impl core::fmt::Display for Error {
             Self::UnexpectedIndefiniteLength(n) => {
                 write!(f, "unexpected indefinite length cbor container at {n}")
             }
+            Self::NotSeverable(n) => write!(f, "section {n} not severable"),
             Self::UnsupportedCommand(n) => write!(f, "command {n} not supported"),
             Self::UnsupportedComponentIdentifier(n) => {
                 write!(f, "component identifier {n} not supported")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -440,7 +440,7 @@ impl<'a, S: AuthState> Envelope<'a, S> {
     /// Retrieve the inner manifest.
     pub fn manifest(&self) -> Result<Manifest<'a, S>, Error> {
         let manifest_bytes = self.manifest_bytes()?;
-        Ok(Manifest::<S>::from_bytes(manifest_bytes))
+        Ok(Manifest::<S>::new(manifest_bytes, self.decoder.clone()))
     }
 }
 

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -1,6 +1,7 @@
 //! Inner SUIT manifest.
 use core::marker::PhantomData;
 
+use digest::Update;
 use minicbor::bytes::ByteSlice;
 use minicbor::data::Token;
 use minicbor::decode::Decoder;
@@ -11,12 +12,13 @@ use crate::component::{ComponentInfo, ComponentIter};
 use crate::consts::SuitCommand;
 use crate::error::Error;
 use crate::manifeststate::ManifestState;
-use crate::{AuthState, Authenticated, OperatingHooks};
+use crate::{AuthState, Authenticated, Envelope, OperatingHooks};
 
 /// Inner SUIT manifest.
 #[derive(Debug, Clone)]
 pub struct Manifest<'a, S: AuthState> {
     decoder: Decoder<'a>,
+    envelope_decoder: Decoder<'a>,
     phantom: PhantomData<S>,
 }
 
@@ -31,9 +33,13 @@ fn try_into_u64(token: Token) -> Result<u64, Error> {
 }
 
 impl<'a, S: AuthState> Manifest<'a, S> {
-    pub(crate) fn from_bytes<STATE: AuthState>(bytes: &'a ByteSlice) -> Manifest<'a, STATE> {
+    pub(crate) fn new<STATE: AuthState>(
+        bytes: &'a ByteSlice,
+        envelope_decoder: Decoder<'a>,
+    ) -> Manifest<'a, STATE> {
         Manifest::<'a, STATE> {
             decoder: Decoder::new(bytes),
+            envelope_decoder,
             phantom: PhantomData,
         }
     }
@@ -85,6 +91,33 @@ impl<'a> Section<'a> {
 }
 
 impl<'a> Manifest<'a, Authenticated> {
+    fn find_severable(
+        &self,
+        section: crate::consts::SuitEnvelope,
+        digest_bytes: &'a [u8],
+    ) -> Result<Option<&'a ByteSlice>, Error> {
+        let digest: crate::digest::SuitDigest = minicbor::decode(digest_bytes)?;
+        let wrapped_section = Envelope {
+            decoder: self.envelope_decoder.clone(),
+            phantom: PhantomData::<Authenticated>,
+        }
+        // Integrity check values are computed over entire bstr enlosing
+        // manifest element (section 8.4.12).
+        .get_object_wrapped(section)?;
+
+        if let Some(section_wrapped_bytes) = wrapped_section {
+            let mut hasher = digest.hasher()?;
+            hasher.update(section_wrapped_bytes);
+            if !digest.match_hasher(hasher)? {
+                Err(Error::AuthenticationFailure)
+            } else {
+                Ok(Some(Decoder::new(section_wrapped_bytes).bytes()?.into()))
+            }
+        } else {
+            Ok(None)
+        }
+    }
+
     fn find_command_sequence(
         &self,
         section: crate::consts::Manifest,
@@ -97,8 +130,20 @@ impl<'a> Manifest<'a, Authenticated> {
             let key = decoder.i16()?;
             let offset = decoder.position();
             if key == section.into() {
-                let value = decoder.bytes()?;
-                return Ok(Some(Section::new(value.into(), offset)));
+                match decoder.datatype()? {
+                    minicbor::data::Type::Bytes => {
+                        let value = decoder.bytes()?;
+                        return Ok(Some(Section::new(value.into(), offset)));
+                    }
+                    // Array means that this is a digest relative to a severed element
+                    minicbor::data::Type::Array => {
+                        let section_key = section.try_into()?;
+                        let section_bytes =
+                            self.find_severable(section_key, decoder.sub_cbor()?)?;
+                        return Ok(section_bytes.map(|b| Section::new(b, offset)));
+                    }
+                    _ => return Err(Error::UnexpectedCbor(offset)),
+                }
             } else {
                 decoder.skip()?;
             }

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -349,3 +349,96 @@ impl<'a> Manifest<'a, Authenticated> {
         Ok(())
     }
 }
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use crate::SuitManifest;
+
+    #[test]
+    fn severable_element_present() {
+        let hex_str = "d86ba4025873825824822f58206a5197ed8f9dccf733d1c89a359441708e\
+070b4c6dcb9a1c2c82c6165f609b90584ad28443a10126a0f65840073d8d\
+80ca67d61cdf04d813c748b2de98fe786fc67b764431307c8dbcbe91dc6f\
+762c2c4d7bb998ff9ead4798e03c8ee26b89ef7a9ad4569f6e187ce89e16\
+c50358d1a80101020203585fa202818141000458568614a40150fa6b4a53\
+d5ad5fdfbe9de663e4d41ffe02501492af1425695e48bf429b2d51f2ab45\
+035824822f582000112233445566778899aabbccddeeff0123456789abcd\
+effedcba98765432100e1987d0010f020f047468747470733a2f2f676974\
+2e696f2f4a4a596f6a074382030f094382170214822f5820cfa90c5c5859\
+5e7f5119a72f803fd0370b3e6abbec6315cd38f63135281bc49817822f58\
+20302196d452bce5e8bfeaf71e395645ede6d365e63507a081379721eeec\
+f0000714583c8614a1157832687474703a2f2f6578616d706c652e636f6d\
+2f766572792f6c6f6e672f706174682f746f2f66696c652f66696c652e62\
+696e1502030f1759020ba165656e2d5553a20179019d2323204578616d70\
+6c6520323a2053696d756c74616e656f757320446f776e6c6f61642c2049\
+6e7374616c6c6174696f6e2c2053656375726520426f6f742c2053657665\
+726564204669656c64730a0a2020202054686973206578616d706c652063\
+6f766572732074686520666f6c6c6f77696e672074656d706c617465733a\
+0a202020200a202020202a20436f6d7061746962696c6974792043686563\
+6b20287b7b74656d706c6174652d636f6d7061746962696c6974792d6368\
+65636b7d7d290a202020202a2053656375726520426f6f7420287b7b7465\
+6d706c6174652d7365637572652d626f6f747d7d290a202020202a204669\
+726d7761726520446f776e6c6f616420287b7b6669726d776172652d646f\
+776e6c6f61642d74656d706c6174657d7d290a202020200a202020205468\
+6973206578616d706c6520616c736f2064656d6f6e737472617465732073\
+6576657261626c6520656c656d656e747320287b7b6f76722d7365766572\
+61626c657d7d292c20616e64207465787420287b7b6d616e69666573742d\
+6469676573742d746578747d7d292e814100a2036761726d2e636f6d0578\
+525468697320636f6d706f6e656e7420697320612064656d6f6e73747261\
+74696f6e2e205468652064696765737420697320612073616d706c652070\
+61747465726e2c206e6f742061207265616c206f6e652e";
+        let manifest_bytes = hex::decode(hex_str).unwrap();
+        let suit_manifest = SuitManifest::from_bytes(&manifest_bytes);
+        let suit_manifest = suit_manifest
+            .authenticate(|_cose, _payload| Ok(true))
+            .unwrap();
+        let envelope = suit_manifest.envelope().unwrap();
+        let manifest = envelope.manifest().unwrap();
+
+        // Install and text are severable and present in the envelope.
+        let install_payload = manifest
+            .find_command_sequence(crate::consts::Manifest::PayloadInstallation)
+            .unwrap();
+        assert!(install_payload.is_some());
+
+        let text = manifest
+            .find_command_sequence(crate::consts::Manifest::TextDescription)
+            .unwrap();
+        assert!(text.is_some());
+    }
+
+    #[test]
+    fn severable_element_absent() {
+        let hex_str = "d86ba2025873825824822f58206a5197ed8f9dccf733d1c89a359441708e\
+070b4c6dcb9a1c2c82c6165f609b90584ad28443a10126a0f65840073d8d\
+80ca67d61cdf04d813c748b2de98fe786fc67b764431307c8dbcbe91dc6f\
+762c2c4d7bb998ff9ead4798e03c8ee26b89ef7a9ad4569f6e187ce89e16\
+c50358d1a80101020203585fa202818141000458568614a40150fa6b4a53\
+d5ad5fdfbe9de663e4d41ffe02501492af1425695e48bf429b2d51f2ab45\
+035824822f582000112233445566778899aabbccddeeff0123456789abcd\
+effedcba98765432100e1987d0010f020f047468747470733a2f2f676974\
+2e696f2f4a4a596f6a074382030f094382170214822f5820cfa90c5c5859\
+5e7f5119a72f803fd0370b3e6abbec6315cd38f63135281bc49817822f58\
+20302196d452bce5e8bfeaf71e395645ede6d365e63507a081379721eeec\
+f00007";
+        let manifest_bytes = hex::decode(hex_str).unwrap();
+        let suit_manifest = SuitManifest::from_bytes(&manifest_bytes);
+        let suit_manifest = suit_manifest
+            .authenticate(|_cose, _payload| Ok(true))
+            .unwrap();
+        let envelope = suit_manifest.envelope().unwrap();
+        let manifest = envelope.manifest().unwrap();
+
+        // Install and texte are severable but absent in the envelope.
+        let install_payload = manifest
+            .find_command_sequence(crate::consts::Manifest::PayloadInstallation)
+            .unwrap();
+        assert!(install_payload.is_none());
+
+        let text = manifest
+            .find_command_sequence(crate::consts::Manifest::TextDescription)
+            .unwrap();
+        assert!(text.is_none());
+    }
+}


### PR DESCRIPTION

### Approach

As discussed, the envelope decoder is cloned and passed to the `Manifest` struct. When `find_command_sequence` encounters a CBOR array instead of a bstr for a section, it treats it as a `SUIT_Digest` and looks up the section in the envelope using the same key. The digest is verified before returning the section bytes, as required by section 8.4.12 of the spec.

If the severed section is absent from the envelope, `None` is returned — the section has been discarded and the caller handles it normally.

### Changes

- `manifest.rs`: add `envelope_decoder` field to `Manifest`, pass it from `Envelope::manifest()`
- `manifest.rs`: `find_command_sequence` now handles both inline bstr and severed digest cases
- `manifest.rs`: add `find_severable` to verify the digest and return the section content
- `consts.rs`: add `TryFrom<Manifest> for SuitEnvelope` to map severable manifest keys to envelope keys

### Notes

- Digest verification happens lazily at access time the spec does not prescribe when verification must occur
- Tests use example B.3 from the SUIT spec covering both the case where the severed section is present in the envelope and the case where it has been discarded

Depends on #7  (error offset correction).