### PR TITLE
feat: Add support for the invoke directive (issue #5)

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -419,6 +419,14 @@ impl<'a, O: OperatingHooks> CommandSequenceExecutor<'a, O> {
         }
     }
 
+    fn directive_invoke(&self, state: &ManifestState, component: &Component) -> Result<(), Error> {
+        if let Some(args) = state.invoke_args {
+            self.os_hooks.invoke(component, args)
+        } else {
+            Err(Error::ParameterNotSet(0))
+        }
+    }
+
     fn decode_reporting_policy(decoder: &mut Decoder) -> Result<ReportingPolicy, Error> {
         Ok(decoder.decode::<ReportingPolicy>()?)
     }

--- a/src/command.rs
+++ b/src/command.rs
@@ -540,6 +540,14 @@ impl<'a, O: OperatingHooks> CommandSequenceExecutor<'a, O> {
         }
     }
 
+    fn directive_invoke(&self, state: &ManifestState, component: &Component) -> Result<(), Error> {
+        if let Some(args) = state.invoke_args {
+            self.os_hooks.invoke(component, args)
+        } else {
+            Err(Error::ParameterNotSet { position: 0 })
+        }
+    }
+
     fn decode_reporting_policy(decoder: &mut Decoder) -> Result<ReportingPolicy, Error> {
         Ok(decoder.decode::<ReportingPolicy>()?)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -330,6 +330,15 @@ pub trait OperatingHooks {
     ) -> Result<(), Error> {
         Err(Error::UnsupportedCommand(SuitCommand::Fetch.into()))
     }
+
+    /// Transfer execution to the current component.
+    fn invoke(
+        &self,
+        _component: &component::Component,
+        _arguments: &ByteSlice,
+    ) -> Result<(), Error> {
+        Err(Error::UnsupportedCommand(SuitCommand::Invoke.into()))
+    }
 }
 
 impl<'a, S: AuthState> SuitManifest<'a, S> {

--- a/src/manifeststate.rs
+++ b/src/manifeststate.rs
@@ -21,6 +21,7 @@ pub(crate) struct ManifestState<'a> {
     pub(crate) component_slot: Option<u64>,
     pub(crate) image_size: Option<usize>,
     pub(crate) uri: Option<&'a str>,
+    pub(crate) invoke_args: Option<&'a ByteSlice>,
 }
 
 impl<'a> ManifestState<'a> {
@@ -114,6 +115,16 @@ impl<'a> ManifestState<'a> {
         Ok(())
     }
 
+    pub(crate) fn set_invoke_args(&mut self, invoke_args: &'a ByteSlice) {
+        self.invoke_args = Some(invoke_args)
+    }
+
+    pub(crate) fn invoke_args_from_cbor(&mut self, decoder: &mut Decoder<'a>) -> Result<(), Error> {
+        let invoke_args = decoder.bytes()?;
+        self.set_invoke_args(invoke_args.into());
+        Ok(())
+    }
+
     pub(crate) fn update_parameter(&mut self, decoder: &mut Decoder<'a>) -> Result<(), Error> {
         let length = decoder.map()?;
         let length = length.ok_or(Error::UnexpectedIndefiniteLength(decoder.position()))?;
@@ -129,6 +140,7 @@ impl<'a> ManifestState<'a> {
                 SuitParameter::SourceComponent => todo!(),
                 SuitParameter::DeviceId => self.device_id_from_cbor(decoder)?,
                 SuitParameter::Content => self.content_from_cbor(decoder)?,
+                SuitParameter::InvokeArgs => self.invoke_args_from_cbor(decoder)?,
                 param => return Err(Error::UnsupportedParameter(param.into())),
             };
         }
@@ -233,6 +245,17 @@ mod tests {
         params.update_parameter(&mut decoder).unwrap();
 
         assert_eq!(params.uri.unwrap(), uri);
+    }
+
+    #[test]
+    fn invoke_args() {
+        let invoke_arg = [0x02];
+        let input = std::vec![0xA1, 0x17, 0x41, 0x02];
+        let mut params = ManifestState::default();
+        let mut decoder = Decoder::new(&input);
+        params.update_parameter(&mut decoder).unwrap();
+
+        assert_eq!(params.invoke_args.unwrap().as_ref(), invoke_arg);
     }
 
     #[test]

--- a/src/manifeststate.rs
+++ b/src/manifeststate.rs
@@ -21,6 +21,7 @@ pub(crate) struct ManifestState<'a> {
     pub(crate) component_slot: Option<u64>,
     pub(crate) image_size: Option<usize>,
     pub(crate) uri: Option<&'a str>,
+    pub(crate) invoke_args: Option<&'a ByteSlice>,
 }
 
 impl<'a> ManifestState<'a> {
@@ -114,6 +115,16 @@ impl<'a> ManifestState<'a> {
         Ok(())
     }
 
+    pub(crate) fn set_invoke_args(&mut self, invoke_args: &'a ByteSlice) {
+        self.invoke_args = Some(invoke_args)
+    }
+
+    pub(crate) fn invoke_args_from_cbor(&mut self, decoder: &mut Decoder<'a>) -> Result<(), Error> {
+        let invoke_args = decoder.bytes()?;
+        self.set_invoke_args(invoke_args.into());
+        Ok(())
+    }
+
     pub(crate) fn update_parameter(&mut self, decoder: &mut Decoder<'a>) -> Result<(), Error> {
         let position = decoder.position();
         let length = decoder.map()?;
@@ -130,6 +141,7 @@ impl<'a> ManifestState<'a> {
                 SuitParameter::SourceComponent => todo!(),
                 SuitParameter::DeviceId => self.device_id_from_cbor(decoder)?,
                 SuitParameter::Content => self.content_from_cbor(decoder)?,
+                SuitParameter::InvokeArgs => self.invoke_args_from_cbor(decoder)?,
                 param => {
                     return Err(Error::UnsupportedParameter {
                         parameter: param.into(),
@@ -241,6 +253,17 @@ mod tests {
         params.update_parameter(&mut decoder).unwrap();
 
         assert_eq!(params.uri.unwrap(), uri);
+    }
+
+    #[test]
+    fn invoke_args() {
+        let invoke_arg = [0x02];
+        let input = std::vec![0xA1, 0x17, 0x41, 0x02];
+        let mut params = ManifestState::default();
+        let mut decoder = Decoder::new(&input);
+        params.update_parameter(&mut decoder).unwrap();
+
+        assert_eq!(params.invoke_args.unwrap().as_ref(), invoke_arg);
     }
 
     #[test]

--- a/src/operatinghooks.rs
+++ b/src/operatinghooks.rs
@@ -86,4 +86,15 @@ pub trait OperatingHooks {
             command: SuitCommand::Fetch.into(),
         })
     }
+
+    /// Transfer execution to the current component.
+    fn invoke(
+        &self,
+        _component: &Component,
+        _arguments: &minicbor::bytes::ByteSlice,
+    ) -> Result<(), Error> {
+        Err(Error::UnsupportedCommand {
+            command: SuitCommand::Fetch.into(),
+        })
+    }
 }


### PR DESCRIPTION


Implements `suit-directive-invoke` which transfers execution to the current component.

**Changes:**
- `lib.rs`: add optional `invoke` method to `OperatingHooks` trait with a default implementation returning `UnsupportedCommand`
- `command.rs`: implement `directive_invoke` which calls `os_hooks.invoke` with the component and optional invoke args
- `manifeststate.rs`: add `invoke_args` parameter with `set_invoke_args` and `invoke_args_from_cbor`

**Notes:**
- `invoke` is optional in `OperatingHooks` implementors that don't need it don't have to implement it
- Arguments are forwarded as-is to the OS hook in an application-specific way (e.g. Linux kernel command line)

Relative to #5 (partial)

!! Depends on #7