### PR TITLE
feat: Add support for copy and swap directives (issue #5)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,10 @@ description = "`no-std` SUIT manifest parser"
 license = "MIT OR Apache-2.0"
 categories = ["no-std"]
 
+[features]
+default = []
+built-in-swap = []
+
 [dependencies]
 ctutils = "0.4.0"
 digest = { version = "0.10.7", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ license = "MIT OR Apache-2.0"
 keywords = ["suit", "updates", "cbor"]
 categories = ["embedded", "no-std"]
 
+
 [dependencies]
 bitflags = { version = "2.11.1", default-features = false }
 ctutils = "0.4.2"
@@ -29,6 +30,7 @@ hex = "0.4.3"
 openssl = "0.10.77"
 
 [features]
+built-in-swap = []
 default = ["sha384", "sha512", "shake128", "shake256"]
 sha384 = []
 sha512 = []

--- a/src/command.rs
+++ b/src/command.rs
@@ -636,6 +636,88 @@ mod tests {
         }
     }
 
+    struct TestHooksMultiple {
+        components: Cell<[[u8; 4]; 2]>,
+    }
+
+    impl TestHooksMultiple {
+        fn new() -> Self {
+            TestHooksMultiple {
+                components: [[0u8; _]; _].into(),
+            }
+        }
+
+        fn component_idx(component: &Component) -> usize {
+            let mut s = heapless::String::<1>::new();
+            component.as_string(&mut s, "").ok();
+            s.as_bytes()[0] as usize
+        }
+    }
+
+    impl OperatingHooks for TestHooksMultiple {
+        type ReadWriteBufferSize = generic_array::typenum::U64;
+        fn match_vendor_id(
+            &self,
+            _uuid: Uuid,
+            _component: &crate::component::Component,
+        ) -> Result<bool, Error> {
+            Ok(true)
+        }
+        fn match_class_id(
+            &self,
+            _uuid: Uuid,
+            _component: &crate::component::Component,
+        ) -> Result<bool, Error> {
+            Ok(true)
+        }
+        fn component_read(
+            &self,
+            component: &crate::component::Component,
+            _slot: Option<u64>,
+            offset: usize,
+            bytes: &mut [u8],
+        ) -> Result<(), Error> {
+            let idx = Self::component_idx(component);
+            let components = self.components.get();
+            if bytes.len() + offset > self.component_size(component).unwrap() {
+                return Err(Error::InvalidCommandSequence(0));
+            }
+            bytes.copy_from_slice(&components[idx][offset..offset + bytes.len()]);
+            Ok(())
+        }
+
+        fn component_write(
+            &self,
+            component: &crate::component::Component,
+            _slot: Option<u64>,
+            offset: usize,
+            bytes: &[u8],
+        ) -> Result<(), Error> {
+            if bytes.len() + offset > self.component_size(component).unwrap() {
+                return Err(Error::InvalidCommandSequence(0));
+            }
+            let idx = Self::component_idx(component);
+            let mut components = self.components.get();
+            components[idx][offset..offset + bytes.len()].copy_from_slice(bytes);
+            self.components.set(components);
+            Ok(())
+        }
+        fn component_capacity(
+            &self,
+            component: &crate::component::Component,
+        ) -> Result<usize, Error> {
+            let idx = Self::component_idx(component);
+            let components = self.components.get();
+            Ok(components[idx].len())
+        }
+
+        fn component_size(&self, component: &crate::component::Component) -> Result<usize, Error> {
+            let idx = Self::component_idx(component);
+            let components = self.components.get();
+            Ok(components[idx].len())
+        }
+    }
+
     fn test_vendor_uuid() -> Uuid {
         uuid!("fa6b4a53-d5ad-5fdf-be9d-e663e4d41ffe")
     }
@@ -659,6 +741,23 @@ mod tests {
 
     fn create_empty_components() -> &'static ByteSlice {
         (&[] as &[u8]).into()
+    }
+
+    const TWO_COMPONENTS: [u8; 7] = [0x82, 0x81, 0x41, 0x00, 0x81, 0x41, 0x01];
+
+    fn create_two_components() -> &'static ByteSlice {
+        (&TWO_COMPONENTS as &[u8]).into()
+    }
+
+    const COMPONENT_0: [u8; 3] = [0x81, 0x41, 0x00];
+    const COMPONENT_1: [u8; 3] = [0x81, 0x41, 0x01];
+
+    fn create_component_0() -> ComponentInfo<'static> {
+        ComponentInfo::new(Component::from_bytes(&COMPONENT_0), 0)
+    }
+
+    fn create_component_1() -> ComponentInfo<'static> {
+        ComponentInfo::new(Component::from_bytes(&COMPONENT_1), 1)
     }
 
     #[test]
@@ -745,6 +844,46 @@ mod tests {
         state.set_image_size(34768);
 
         assert_eq!(res.unwrap(), state);
+    }
+
+    #[test]
+    fn copy_component() {
+        let hooks = TestHooksMultiple::new();
+        // Set component 1 buf to known value
+        let mut components = hooks.components.get();
+        components[1] = [0x01, 0x02, 0x03, 0x04];
+        hooks.components.set(components);
+
+        let info = create_component_0();
+        let state = ManifestState::default();
+
+        // [override-parameters {source_component: 1}, copy, reporting_policy]
+        let cmd: &[u8] = &[0x84, 0x14, 0xA1, 0x16, 0x01, 0x16, 0x02];
+        let sequence = CommandSequenceExecutor::new(cmd.into(), create_two_components(), &hooks);
+        let res = sequence.process(state, &info);
+        assert!(res.is_ok());
+        // composant 0 doit contenir la valeur de composant 1
+        assert_eq!(hooks.components.get()[0], [0x01, 0x02, 0x03, 0x04]);
+    }
+
+    #[test]
+    fn swap_components() {
+        let hooks = TestHooksMultiple::new();
+        let mut components = hooks.components.get();
+        components[0] = [0xAA, 0xBB, 0xCC, 0xDD];
+        components[1] = [0x01, 0x02, 0x03, 0x04];
+        hooks.components.set(components);
+
+        let info = create_component_0();
+        let state = ManifestState::default();
+
+        // [override-parameters {source_component: 1}, swap, reporting_policy]
+        let cmd: &[u8] = &[0x84, 0x14, 0xA1, 0x16, 0x01, 0x18, 0x1F, 0x02];
+        let sequence = CommandSequenceExecutor::new(cmd.into(), create_two_components(), &hooks);
+        let res = sequence.process(state, &info);
+        assert!(res.is_ok());
+        assert_eq!(hooks.components.get()[0], [0x01, 0x02, 0x03, 0x04]);
+        assert_eq!(hooks.components.get()[1], [0xAA, 0xBB, 0xCC, 0xDD]);
     }
 
     #[test]

--- a/src/command.rs
+++ b/src/command.rs
@@ -251,9 +251,7 @@ impl<'a, O: OperatingHooks> CommandSequenceExecutor<'a, O> {
                     SuitCommand::RunSequence => {
                         Err(Error::UnsupportedCommand(SuitCommand::RunSequence.into()))?
                     }
-                    SuitCommand::Swap => {
-                        Err(Error::UnsupportedCommand(SuitCommand::RunSequence.into()))?
-                    }
+                    SuitCommand::Swap => self.directive_swap(&state, component, self.components)?,
                     SuitCommand::TryEach => {
                         self.try_each(&mut state, component, command.get_argument_cbor()?)
                             .map_err(|e| e.add_offset(command.get_argument_offset()))?;
@@ -470,6 +468,76 @@ impl<'a, O: OperatingHooks> CommandSequenceExecutor<'a, O> {
                         buf,
                     )?;
                 }
+                return Ok(());
+            }
+        }
+        Err(Error::InvalidSourceComponent(source_index))
+    }
+
+    fn directive_swap(
+        &self,
+        state: &ManifestState,
+        component: &ComponentInfo,
+        components: &'a ByteSlice,
+    ) -> Result<(), Error> {
+        let source_index = state.source_component.ok_or(Error::ParameterNotSet(0))?;
+        if source_index == component.index {
+            return Err(Error::SameSourceAndTarget(source_index));
+        }
+        let mut decoder = Decoder::new(components);
+        for (idx, source) in ComponentIter::new(&mut decoder)?.enumerate() {
+            if (idx as u32) == source_index {
+                let source_component = source?;
+
+                if state.image_digest.is_some() && state.image_size.is_some() {
+                    // Check if data is different before copying
+                    if self.cond_image_match(state, component.component()).is_ok() {
+                        return Ok(());
+                    }
+
+                    // Avoid copy of corrupted image
+                    self.cond_image_match(state, &source_component)?;
+                }
+
+                let source_size = self.os_hooks.component_size(&source_component)?;
+
+                let mut read_source_buf = RwBuf::<O::ReadWriteBufferSize>::new().buf;
+                let mut read_target_buf = RwBuf::<O::ReadWriteBufferSize>::new().buf;
+
+                for offset in (0..source_size).step_by(read_source_buf.len()) {
+                    let diff = source_size.saturating_sub(offset);
+                    let read_size = if diff < read_source_buf.len() {
+                        diff
+                    } else {
+                        read_source_buf.len()
+                    };
+
+                    self.os_hooks.component_read(
+                        &source_component,
+                        state.component_slot,
+                        offset,
+                        &mut read_source_buf[0..read_size],
+                    )?;
+                    self.os_hooks.component_read(
+                        component.component(),
+                        state.component_slot,
+                        offset,
+                        &mut read_target_buf[0..read_size],
+                    )?;
+                    self.os_hooks.component_write(
+                        &source_component,
+                        state.component_slot,
+                        offset,
+                        &read_target_buf[0..read_size],
+                    )?;
+                    self.os_hooks.component_write(
+                        component.component(),
+                        state.component_slot,
+                        offset,
+                        &read_source_buf[0..read_size],
+                    )?;
+                }
+
                 return Ok(());
             }
         }

--- a/src/command.rs
+++ b/src/command.rs
@@ -499,46 +499,56 @@ impl<'a, O: OperatingHooks> CommandSequenceExecutor<'a, O> {
                     self.cond_image_match(state, &source_component)?;
                 }
 
-                let source_size = self.os_hooks.component_size(&source_component)?;
-
-                let mut read_source_buf = RwBuf::<O::ReadWriteBufferSize>::new().buf;
-                let mut read_target_buf = RwBuf::<O::ReadWriteBufferSize>::new().buf;
-
-                for offset in (0..source_size).step_by(read_source_buf.len()) {
-                    let diff = source_size.saturating_sub(offset);
-                    let read_size = if diff < read_source_buf.len() {
-                        diff
-                    } else {
-                        read_source_buf.len()
-                    };
-
-                    self.os_hooks.component_read(
-                        &source_component,
-                        state.component_slot,
-                        offset,
-                        &mut read_source_buf[0..read_size],
-                    )?;
-                    self.os_hooks.component_read(
-                        component.component(),
-                        state.component_slot,
-                        offset,
-                        &mut read_target_buf[0..read_size],
-                    )?;
-                    self.os_hooks.component_write(
-                        &source_component,
-                        state.component_slot,
-                        offset,
-                        &read_target_buf[0..read_size],
-                    )?;
-                    self.os_hooks.component_write(
-                        component.component(),
-                        state.component_slot,
-                        offset,
-                        &read_source_buf[0..read_size],
-                    )?;
+                #[cfg(not(feature = "built-in-swap"))]
+                {
+                    self.os_hooks
+                        .swap(component.component(), &source_component)?;
+                    return Ok(());
                 }
 
-                return Ok(());
+                #[cfg(feature = "built-in-swap")]
+                {
+                    let source_size = self.os_hooks.component_size(&source_component)?;
+
+                    let mut read_source_buf = RwBuf::<O::ReadWriteBufferSize>::new().buf;
+                    let mut read_target_buf = RwBuf::<O::ReadWriteBufferSize>::new().buf;
+
+                    for offset in (0..source_size).step_by(read_source_buf.len()) {
+                        let diff = source_size.saturating_sub(offset);
+                        let read_size = if diff < read_source_buf.len() {
+                            diff
+                        } else {
+                            read_source_buf.len()
+                        };
+
+                        self.os_hooks.component_read(
+                            &source_component,
+                            state.component_slot,
+                            offset,
+                            &mut read_source_buf[0..read_size],
+                        )?;
+                        self.os_hooks.component_read(
+                            component.component(),
+                            state.component_slot,
+                            offset,
+                            &mut read_target_buf[0..read_size],
+                        )?;
+                        self.os_hooks.component_write(
+                            &source_component,
+                            state.component_slot,
+                            offset,
+                            &read_target_buf[0..read_size],
+                        )?;
+                        self.os_hooks.component_write(
+                            component.component(),
+                            state.component_slot,
+                            offset,
+                            &read_source_buf[0..read_size],
+                        )?;
+                    }
+
+                    return Ok(());
+                }
             }
         }
         Err(Error::InvalidSourceComponent(source_index))
@@ -867,7 +877,8 @@ mod tests {
     }
 
     #[test]
-    fn swap_components() {
+    #[cfg(feature = "built-in-swap")]
+    fn swap_fallback() {
         let hooks = TestHooksMultiple::new();
         let mut components = hooks.components.get();
         components[0] = [0xAA, 0xBB, 0xCC, 0xDD];

--- a/src/command.rs
+++ b/src/command.rs
@@ -7,7 +7,7 @@ use minicbor::bytes::ByteSlice;
 use minicbor::Decoder;
 
 use crate::cbor::SubCbor;
-use crate::component::{Component, ComponentInfo};
+use crate::component::{Component, ComponentInfo, ComponentIter};
 use crate::consts::SuitCommand;
 use crate::error::Error;
 use crate::manifeststate::ManifestState;
@@ -133,13 +133,20 @@ impl<N: generic_array::ArrayLength> RwBuf<N> {
 #[derive(Debug, Clone)]
 pub(crate) struct CommandSequenceExecutor<'a, O: OperatingHooks> {
     command_sequence: &'a ByteSlice,
+    // Components list is needed by Copy and swap
+    components: &'a ByteSlice,
     os_hooks: &'a O,
 }
 
 impl<'a, O: OperatingHooks> CommandSequenceExecutor<'a, O> {
-    pub(crate) fn new(command_sequence: &'a ByteSlice, os_hooks: &'a O) -> Self {
+    pub(crate) fn new(
+        command_sequence: &'a ByteSlice,
+        components: &'a ByteSlice,
+        os_hooks: &'a O,
+    ) -> Self {
         Self {
             command_sequence,
+            components,
             os_hooks,
         }
     }
@@ -155,7 +162,7 @@ impl<'a, O: OperatingHooks> CommandSequenceExecutor<'a, O> {
             if seq.is_empty() {
                 return Ok(());
             }
-            let try_sequence = CommandSequenceExecutor::new(seq, self.os_hooks);
+            let try_sequence = CommandSequenceExecutor::new(seq, self.components, self.os_hooks);
             let res = try_sequence.process(state.clone(), component);
             if let Ok(res) = res {
                 *state = res;
@@ -226,7 +233,7 @@ impl<'a, O: OperatingHooks> CommandSequenceExecutor<'a, O> {
                     SuitCommand::ComponentSlot => {
                         self.cond_component_slot(&state, component.component())?;
                     }
-                    SuitCommand::Copy => Err(Error::UnsupportedCommand(SuitCommand::Copy.into()))?,
+                    SuitCommand::Copy => self.directive_copy(&state, component, self.components)?,
                     SuitCommand::DeviceIdentifier => {
                         self.cond_device_identifier(&state, component.component())?;
                     }
@@ -419,6 +426,56 @@ impl<'a, O: OperatingHooks> CommandSequenceExecutor<'a, O> {
         }
     }
 
+    fn directive_copy(
+        &self,
+        state: &ManifestState,
+        component: &ComponentInfo,
+        components: &'a ByteSlice,
+    ) -> Result<(), Error> {
+        let source_index = state.source_component.ok_or(Error::ParameterNotSet(0))?;
+        if source_index == component.index {
+            return Err(Error::SameSourceAndTarget(source_index));
+        }
+        let mut decoder = Decoder::new(components);
+        for (idx, source) in ComponentIter::new(&mut decoder)?.enumerate() {
+            if (idx as u32) == source_index {
+                let source_component = source?;
+                let size = self.os_hooks.component_size(&source_component)?;
+
+                if state.image_digest.is_some() && state.image_size.is_some() {
+                    // Check if data is different before copying
+                    if self.cond_image_match(state, component.component()).is_ok() {
+                        return Ok(());
+                    }
+
+                    // Avoid copy of corrupted image
+                    self.cond_image_match(state, &source_component)?;
+                }
+
+                let mut buf = RwBuf::<O::ReadWriteBufferSize>::new().buf;
+                for offset in (0..size).step_by(buf.len()) {
+                    let diff = size.saturating_sub(offset);
+                    let read_size = if diff < buf.len() { diff } else { buf.len() };
+                    let buf = &mut buf[0..read_size];
+                    self.os_hooks.component_read(
+                        &source_component,
+                        state.component_slot,
+                        offset,
+                        buf,
+                    )?;
+                    self.os_hooks.component_write(
+                        component.component(),
+                        state.component_slot,
+                        offset,
+                        buf,
+                    )?;
+                }
+                return Ok(());
+            }
+        }
+        Err(Error::InvalidSourceComponent(source_index))
+    }
+
     fn decode_reporting_policy(decoder: &mut Decoder) -> Result<ReportingPolicy, Error> {
         Ok(decoder.decode::<ReportingPolicy>()?)
     }
@@ -532,13 +589,18 @@ mod tests {
         ComponentInfo::new(component, 0)
     }
 
+    fn create_empty_components() -> &'static ByteSlice {
+        (&[] as &[u8]).into()
+    }
+
     #[test]
     fn invalid_sequence() {
         let input: &[u8] = &std::vec![0x83, 0x14, 0x05, 0x15,];
 
         let hooks = create_test_hooks();
         let info = create_test_component();
-        let sequence = CommandSequenceExecutor::new(input.into(), &hooks);
+        let sequence =
+            CommandSequenceExecutor::new(input.into(), create_empty_components(), &hooks);
         let state = ManifestState::default();
         let res = sequence.process(state, &info).unwrap_err();
         assert_eq!(res, Error::InvalidCommandSequence(1));
@@ -550,7 +612,8 @@ mod tests {
 
         let hooks = create_test_hooks();
         let info = create_test_component();
-        let sequence = CommandSequenceExecutor::new(input.into(), &hooks);
+        let sequence =
+            CommandSequenceExecutor::new(input.into(), create_empty_components(), &hooks);
         let state = ManifestState::default();
         let res = sequence.process(state, &info).unwrap_err();
         assert_eq!(res, Error::InvalidCommandSequence(1));
@@ -562,7 +625,8 @@ mod tests {
 
         let hooks = create_test_hooks();
         let info = create_test_component();
-        let sequence = CommandSequenceExecutor::new(input.into(), &hooks);
+        let sequence =
+            CommandSequenceExecutor::new(input.into(), create_empty_components(), &hooks);
         let state = ManifestState::default();
         let res = sequence.process(state.clone(), &info).unwrap_err();
         assert_eq!(res, Error::UnsupportedCommand(0));
@@ -574,7 +638,8 @@ mod tests {
         let state = ManifestState::default();
         let hooks = create_test_hooks();
         let info = create_test_component();
-        let sequence = CommandSequenceExecutor::new(input.into(), &hooks);
+        let sequence =
+            CommandSequenceExecutor::new(input.into(), create_empty_components(), &hooks);
 
         let res = sequence.process(state, &info).unwrap();
         assert_eq!(res.component_slot, None);
@@ -593,7 +658,8 @@ mod tests {
         ];
 
         let hooks = create_test_hooks();
-        let sequence = CommandSequenceExecutor::new(input.into(), &hooks);
+        let sequence =
+            CommandSequenceExecutor::new(input.into(), create_empty_components(), &hooks);
         let mut state = ManifestState::default();
         let info = create_test_component();
 
@@ -628,7 +694,8 @@ mod tests {
         let hooks = create_test_hooks();
         let info = create_test_component();
 
-        let sequence = CommandSequenceExecutor::new(input.into(), &hooks);
+        let sequence =
+            CommandSequenceExecutor::new(input.into(), create_empty_components(), &hooks);
         let res = sequence.process(state.clone(), &info);
         assert!(res.is_ok());
     }
@@ -644,7 +711,8 @@ mod tests {
         let info = create_test_component();
 
         let state = ManifestState::default();
-        let sequence = CommandSequenceExecutor::new(input.into(), &hooks);
+        let sequence =
+            CommandSequenceExecutor::new(input.into(), create_empty_components(), &hooks);
         let res = sequence.process(state.clone(), &info).unwrap();
         assert_eq!(res.component_slot, Some(2));
     }
@@ -656,7 +724,8 @@ mod tests {
         let info = create_test_component();
 
         let state = ManifestState::default();
-        let sequence = CommandSequenceExecutor::new(input.into(), &hooks);
+        let sequence =
+            CommandSequenceExecutor::new(input.into(), create_empty_components(), &hooks);
         let res = sequence.process(state.clone(), &info).unwrap_err();
         assert_eq!(res, Error::TryEachFail(7));
     }
@@ -671,7 +740,8 @@ mod tests {
         let info = create_test_component();
 
         let state = ManifestState::default();
-        let sequence = CommandSequenceExecutor::new(input.into(), &hooks);
+        let sequence =
+            CommandSequenceExecutor::new(input.into(), create_empty_components(), &hooks);
         let res = sequence.process(state.clone(), &info).unwrap_err();
         assert_eq!(res, Error::UnsupportedParameter(0));
     }
@@ -685,7 +755,8 @@ mod tests {
         let info = create_test_component();
 
         let state = ManifestState::default();
-        let sequence = CommandSequenceExecutor::new(input.into(), &hooks);
+        let sequence =
+            CommandSequenceExecutor::new(input.into(), create_empty_components(), &hooks);
         let res = sequence.process(state.clone(), &info).unwrap();
         assert_eq!(res.component_slot, Some(2));
     }
@@ -697,7 +768,8 @@ mod tests {
         let info = create_test_component();
 
         let state = ManifestState::default();
-        let sequence = CommandSequenceExecutor::new(input.into(), &hooks);
+        let sequence =
+            CommandSequenceExecutor::new(input.into(), create_empty_components(), &hooks);
         let res = sequence.process(state.clone(), &info);
         assert_eq!(res, Ok(state));
     }

--- a/src/command.rs
+++ b/src/command.rs
@@ -8,7 +8,7 @@ use minicbor::bytes::ByteSlice;
 use minicbor::Decoder;
 
 use crate::cbor::SubCbor;
-use crate::component::{Component, ComponentInfo};
+use crate::component::{Component, ComponentInfo, ComponentIter};
 use crate::consts::SuitCommand;
 use crate::error::Error;
 use crate::manifeststate::ManifestState;
@@ -174,9 +174,11 @@ impl<'a> CommandSequence<'a> {
         &self,
         state: ManifestState<'a>,
         component_info: &'a ComponentInfo<'a>,
+        components: &'a ByteSlice,
         os_hooks: &'a impl OperatingHooks,
     ) -> Result<ManifestState<'a>, Error> {
-        let executor = CommandSequenceExecutor::new(self.sequence, self.offset, os_hooks);
+        let executor =
+            CommandSequenceExecutor::new(self.sequence, components, self.offset, os_hooks);
         executor
             .process(state, component_info)
             .map_err(|e| e.add_offset(self.offset))
@@ -228,14 +230,22 @@ impl<'a> CommandSequence<'a> {
 #[derive(Debug, Clone)]
 pub(crate) struct CommandSequenceExecutor<'a, O: OperatingHooks> {
     command_sequence: &'a ByteSlice,
+    // Components list is needed by Copy and swap
+    components: &'a ByteSlice,
     offset: usize,
     os_hooks: &'a O,
 }
 
 impl<'a, O: OperatingHooks> CommandSequenceExecutor<'a, O> {
-    fn new(command_sequence: &'a ByteSlice, offset: usize, os_hooks: &'a O) -> Self {
+    fn new(
+        command_sequence: &'a ByteSlice,
+        components: &'a ByteSlice,
+        offset: usize,
+        os_hooks: &'a O,
+    ) -> Self {
         Self {
             command_sequence,
+            components,
             offset,
             os_hooks,
         }
@@ -257,6 +267,7 @@ impl<'a, O: OperatingHooks> CommandSequenceExecutor<'a, O> {
             let res = CommandSequence::new(sequence, 0).execute(
                 state.clone(),
                 component_info,
+                self.components,
                 self.os_hooks,
             );
             match res {
@@ -319,9 +330,7 @@ impl<'a, O: OperatingHooks> CommandSequenceExecutor<'a, O> {
             SuitCommand::ComponentSlot => {
                 self.cond_component_slot(state, component)?;
             }
-            SuitCommand::Copy => Err(Error::UnsupportedCommand {
-                command: SuitCommand::Copy.into(),
-            })?,
+            SuitCommand::Copy => self.directive_copy(state, component_info, self.components)?,
             SuitCommand::DeviceIdentifier => {
                 self.cond_device_identifier(state, component)?;
             }
@@ -548,6 +557,62 @@ impl<'a, O: OperatingHooks> CommandSequenceExecutor<'a, O> {
         }
     }
 
+    fn directive_copy(
+        &self,
+        state: &ManifestState,
+        component: &ComponentInfo,
+        components: &'a ByteSlice,
+    ) -> Result<(), Error> {
+        let Some(source_index) = state.source_component else {
+            return Err(Error::ParameterNotSet { position: 0 });
+        };
+        if source_index == component.index {
+            return Err(Error::SameSourceAndTarget {
+                identifier: source_index,
+            });
+        }
+        let mut decoder = Decoder::new(components);
+        for (idx, source) in ComponentIter::new(&mut decoder)?.enumerate() {
+            if (idx as u32) == source_index {
+                let source_component = source?;
+                let size = self.os_hooks.component_size(&source_component)?;
+
+                if state.image_digest.is_some() && state.image_size.is_some() {
+                    // Check if data is different before copying
+                    if self.cond_image_match(state, component.component()).is_ok() {
+                        return Ok(());
+                    }
+
+                    // Avoid copy of corrupted image
+                    self.cond_image_match(state, &source_component)?;
+                }
+
+                let mut buf = RwBuf::<O::ReadWriteBufferSize>::new().buf;
+                for offset in (0..size).step_by(buf.len()) {
+                    let diff = size.saturating_sub(offset);
+                    let read_size = if diff < buf.len() { diff } else { buf.len() };
+                    let buf = &mut buf[0..read_size];
+                    self.os_hooks.component_read(
+                        &source_component,
+                        state.component_slot,
+                        offset,
+                        buf,
+                    )?;
+                    self.os_hooks.component_write(
+                        component.component(),
+                        state.component_slot,
+                        offset,
+                        buf,
+                    )?;
+                }
+                return Ok(());
+            }
+        }
+        Err(Error::InvalidSourceComponent {
+            identifier: source_index,
+        })
+    }
+
     fn decode_reporting_policy(decoder: &mut Decoder) -> Result<ReportingPolicy, Error> {
         Ok(decoder.decode::<ReportingPolicy>()?)
     }
@@ -661,13 +726,18 @@ mod tests {
         ComponentInfo::new(component, 0)
     }
 
+    fn create_empty_components() -> &'static ByteSlice {
+        (&[] as &[u8]).into()
+    }
+
     #[test]
     fn invalid_sequence() {
         let input: &[u8] = &std::vec![0x83, 0x14, 0x05, 0x15,];
 
         let hooks = create_test_hooks();
         let info = create_test_component();
-        let sequence = CommandSequenceExecutor::new(input.into(), 0, &hooks);
+        let sequence =
+            CommandSequenceExecutor::new(input.into(), create_empty_components(), 0, &hooks);
         let state = ManifestState::default();
         let res = sequence.process(state, &info).unwrap_err();
         assert_eq!(res, Error::InvalidCommandSequence { position: 0 });
@@ -684,7 +754,8 @@ mod tests {
 
         let hooks = create_test_hooks();
         let info = create_test_component();
-        let sequence = CommandSequenceExecutor::new(input.into(), 0, &hooks);
+        let sequence =
+            CommandSequenceExecutor::new(input.into(), create_empty_components(), 0, &hooks);
         let state = ManifestState::default();
         let res = sequence.process(state, &info).unwrap_err();
         assert_eq!(res, Error::InvalidCommandSequence { position: 0 });
@@ -701,7 +772,8 @@ mod tests {
 
         let hooks = create_test_hooks();
         let info = create_test_component();
-        let sequence = CommandSequenceExecutor::new(input.into(), 0, &hooks);
+        let sequence =
+            CommandSequenceExecutor::new(input.into(), create_empty_components(), 0, &hooks);
         let state = ManifestState::default();
         let res = sequence.process(state, &info).unwrap_err();
         assert_eq!(res, Error::UnsupportedCommand { command: 0 });
@@ -718,7 +790,8 @@ mod tests {
         let state = ManifestState::default();
         let hooks = create_test_hooks();
         let info = create_test_component();
-        let sequence = CommandSequenceExecutor::new(input.into(), 0, &hooks);
+        let sequence =
+            CommandSequenceExecutor::new(input.into(), create_empty_components(), 0, &hooks);
 
         let res = sequence.process(state, &info).unwrap();
         assert_eq!(res.component_slot, None);
@@ -735,7 +808,8 @@ mod tests {
         let state = ManifestState::default();
         let hooks = create_test_hooks();
         let info = create_test_component();
-        let sequence = CommandSequenceExecutor::new(input.into(), 0, &hooks);
+        let sequence =
+            CommandSequenceExecutor::new(input.into(), create_empty_components(), 0, &hooks);
 
         let res = sequence.process(state, &info).unwrap_err();
         assert_eq!(res, Error::ParameterNotSet { position: 1 });
@@ -759,7 +833,8 @@ mod tests {
         ];
 
         let hooks = create_test_hooks();
-        let sequence = CommandSequenceExecutor::new(input.into(), 0, &hooks);
+        let sequence =
+            CommandSequenceExecutor::new(input.into(), create_empty_components(), 0, &hooks);
         let mut state = ManifestState::default();
         let info = create_test_component();
 
@@ -802,7 +877,8 @@ mod tests {
         let hooks = create_test_hooks();
         let info = create_test_component();
 
-        let sequence = CommandSequenceExecutor::new(input.into(), 0, &hooks);
+        let sequence =
+            CommandSequenceExecutor::new(input.into(), create_empty_components(), 0, &hooks);
         let res = sequence.process(state, &info);
         assert!(res.is_ok());
 
@@ -828,7 +904,8 @@ mod tests {
         let info = create_test_component();
 
         let state = ManifestState::default();
-        let sequence = CommandSequenceExecutor::new(input.into(), 0, &hooks);
+        let sequence =
+            CommandSequenceExecutor::new(input.into(), create_empty_components(), 0, &hooks);
         let res = sequence.process(state, &info).unwrap();
         assert_eq!(res.component_slot, Some(2));
 
@@ -845,14 +922,16 @@ mod tests {
         let info = create_test_component();
 
         let state = ManifestState::default();
-        let sequence = CommandSequenceExecutor::new(input.into(), 0, &hooks);
+        let sequence =
+            CommandSequenceExecutor::new(input.into(), create_empty_components(), 0, &hooks);
         let res = sequence.process(state, &info).unwrap_err();
         assert_eq!(res, Error::TryEachFail { position: 5 });
 
         let input: &[u8] =
             &std::vec![0x82, 0x0F, 0x82, 0x43, 0x82, 0x0E, 0x05, 0x43, 0x82, 0x0E, 0x05];
         let state = ManifestState::default();
-        let sequence = CommandSequenceExecutor::new(input.into(), 0, &hooks);
+        let sequence =
+            CommandSequenceExecutor::new(input.into(), create_empty_components(), 0, &hooks);
         let res = sequence.process(state, &info).unwrap_err();
         assert_eq!(res, Error::TryEachFail { position: 9 });
     }
@@ -867,7 +946,8 @@ mod tests {
         let info = create_test_component();
 
         let state = ManifestState::default();
-        let sequence = CommandSequenceExecutor::new(input.into(), 0, &hooks);
+        let sequence =
+            CommandSequenceExecutor::new(input.into(), create_empty_components(), 0, &hooks);
         let res = sequence.process(state, &info).unwrap_err();
         assert_eq!(res, Error::UnsupportedParameter { parameter: 0 });
     }
@@ -881,7 +961,8 @@ mod tests {
         let info = create_test_component();
 
         let state = ManifestState::default();
-        let sequence = CommandSequenceExecutor::new(input.into(), 0, &hooks);
+        let sequence =
+            CommandSequenceExecutor::new(input.into(), create_empty_components(), 0, &hooks);
         let res = sequence.process(state, &info).unwrap();
         assert_eq!(res.component_slot, Some(2));
     }
@@ -893,7 +974,8 @@ mod tests {
         let info = create_test_component();
 
         let state = ManifestState::default();
-        let sequence = CommandSequenceExecutor::new(input.into(), 0, &hooks);
+        let sequence =
+            CommandSequenceExecutor::new(input.into(), create_empty_components(), 0, &hooks);
         let res = sequence.process(state.clone(), &info);
         assert_eq!(res, Ok(state));
 

--- a/src/command.rs
+++ b/src/command.rs
@@ -640,46 +640,56 @@ impl<'a, O: OperatingHooks> CommandSequenceExecutor<'a, O> {
                     self.cond_image_match(state, &source_component)?;
                 }
 
-                let source_size = self.os_hooks.component_size(&source_component)?;
-
-                let mut read_source_buf = RwBuf::<O::ReadWriteBufferSize>::new().buf;
-                let mut read_target_buf = RwBuf::<O::ReadWriteBufferSize>::new().buf;
-
-                for offset in (0..source_size).step_by(read_source_buf.len()) {
-                    let diff = source_size.saturating_sub(offset);
-                    let read_size = if diff < read_source_buf.len() {
-                        diff
-                    } else {
-                        read_source_buf.len()
-                    };
-
-                    self.os_hooks.component_read(
-                        &source_component,
-                        state.component_slot,
-                        offset,
-                        &mut read_source_buf[0..read_size],
-                    )?;
-                    self.os_hooks.component_read(
-                        component.component(),
-                        state.component_slot,
-                        offset,
-                        &mut read_target_buf[0..read_size],
-                    )?;
-                    self.os_hooks.component_write(
-                        &source_component,
-                        state.component_slot,
-                        offset,
-                        &read_target_buf[0..read_size],
-                    )?;
-                    self.os_hooks.component_write(
-                        component.component(),
-                        state.component_slot,
-                        offset,
-                        &read_source_buf[0..read_size],
-                    )?;
+                #[cfg(not(feature = "built-in-swap"))]
+                {
+                    self.os_hooks
+                        .swap(component.component(), &source_component)?;
+                    return Ok(());
                 }
 
-                return Ok(());
+                #[cfg(feature = "built-in-swap")]
+                {
+                    let source_size = self.os_hooks.component_size(&source_component)?;
+
+                    let mut read_source_buf = RwBuf::<O::ReadWriteBufferSize>::new().buf;
+                    let mut read_target_buf = RwBuf::<O::ReadWriteBufferSize>::new().buf;
+
+                    for offset in (0..source_size).step_by(read_source_buf.len()) {
+                        let diff = source_size.saturating_sub(offset);
+                        let read_size = if diff < read_source_buf.len() {
+                            diff
+                        } else {
+                            read_source_buf.len()
+                        };
+
+                        self.os_hooks.component_read(
+                            &source_component,
+                            state.component_slot,
+                            offset,
+                            &mut read_source_buf[0..read_size],
+                        )?;
+                        self.os_hooks.component_read(
+                            component.component(),
+                            state.component_slot,
+                            offset,
+                            &mut read_target_buf[0..read_size],
+                        )?;
+                        self.os_hooks.component_write(
+                            &source_component,
+                            state.component_slot,
+                            offset,
+                            &read_target_buf[0..read_size],
+                        )?;
+                        self.os_hooks.component_write(
+                            component.component(),
+                            state.component_slot,
+                            offset,
+                            &read_source_buf[0..read_size],
+                        )?;
+                    }
+
+                    return Ok(());
+                }
             }
         }
         Err(Error::InvalidSourceComponent {
@@ -823,7 +833,7 @@ mod tests {
             let idx = Self::component_idx(component);
             let components = self.components.get();
             if bytes.len() + offset > self.component_size(component).unwrap() {
-                return Err(Error::InvalidCommandSequence(0));
+                return Err(Error::InvalidCommandSequence { position: 0 });
             }
             bytes.copy_from_slice(&components[idx][offset..offset + bytes.len()]);
             Ok(())
@@ -837,7 +847,7 @@ mod tests {
             bytes: &[u8],
         ) -> Result<(), Error> {
             if bytes.len() + offset > self.component_size(component).unwrap() {
-                return Err(Error::InvalidCommandSequence(0));
+                return Err(Error::InvalidCommandSequence { position: 0 });
             }
             let idx = Self::component_idx(component);
             let mut components = self.components.get();
@@ -1048,7 +1058,7 @@ mod tests {
 
         // [override-parameters {source_component: 1}, copy, reporting_policy]
         let cmd: &[u8] = &[0x84, 0x14, 0xA1, 0x16, 0x01, 0x16, 0x02];
-        let sequence = CommandSequenceExecutor::new(cmd.into(), create_two_components(), &hooks);
+        let sequence = CommandSequenceExecutor::new(cmd.into(), create_two_components(), 0, &hooks);
         let res = sequence.process(state, &info);
         assert!(res.is_ok());
         // composant 0 doit contenir la valeur de composant 1
@@ -1056,7 +1066,8 @@ mod tests {
     }
 
     #[test]
-    fn swap_components() {
+    #[cfg(feature = "built-in-swap")]
+    fn swap_fallback() {
         let hooks = TestHooksMultiple::new();
         let mut components = hooks.components.get();
         components[0] = [0xAA, 0xBB, 0xCC, 0xDD];

--- a/src/command.rs
+++ b/src/command.rs
@@ -779,6 +779,88 @@ mod tests {
         }
     }
 
+    struct TestHooksMultiple {
+        components: Cell<[[u8; 4]; 2]>,
+    }
+
+    impl TestHooksMultiple {
+        fn new() -> Self {
+            TestHooksMultiple {
+                components: [[0u8; _]; _].into(),
+            }
+        }
+
+        fn component_idx(component: &Component) -> usize {
+            let mut s = heapless::String::<1>::new();
+            component.as_string(&mut s, "").ok();
+            s.as_bytes()[0] as usize
+        }
+    }
+
+    impl OperatingHooks for TestHooksMultiple {
+        type ReadWriteBufferSize = generic_array::typenum::U64;
+        fn match_vendor_id(
+            &self,
+            _uuid: Uuid,
+            _component: &crate::component::Component,
+        ) -> Result<bool, Error> {
+            Ok(true)
+        }
+        fn match_class_id(
+            &self,
+            _uuid: Uuid,
+            _component: &crate::component::Component,
+        ) -> Result<bool, Error> {
+            Ok(true)
+        }
+        fn component_read(
+            &self,
+            component: &crate::component::Component,
+            _slot: Option<u64>,
+            offset: usize,
+            bytes: &mut [u8],
+        ) -> Result<(), Error> {
+            let idx = Self::component_idx(component);
+            let components = self.components.get();
+            if bytes.len() + offset > self.component_size(component).unwrap() {
+                return Err(Error::InvalidCommandSequence(0));
+            }
+            bytes.copy_from_slice(&components[idx][offset..offset + bytes.len()]);
+            Ok(())
+        }
+
+        fn component_write(
+            &self,
+            component: &crate::component::Component,
+            _slot: Option<u64>,
+            offset: usize,
+            bytes: &[u8],
+        ) -> Result<(), Error> {
+            if bytes.len() + offset > self.component_size(component).unwrap() {
+                return Err(Error::InvalidCommandSequence(0));
+            }
+            let idx = Self::component_idx(component);
+            let mut components = self.components.get();
+            components[idx][offset..offset + bytes.len()].copy_from_slice(bytes);
+            self.components.set(components);
+            Ok(())
+        }
+        fn component_capacity(
+            &self,
+            component: &crate::component::Component,
+        ) -> Result<usize, Error> {
+            let idx = Self::component_idx(component);
+            let components = self.components.get();
+            Ok(components[idx].len())
+        }
+
+        fn component_size(&self, component: &crate::component::Component) -> Result<usize, Error> {
+            let idx = Self::component_idx(component);
+            let components = self.components.get();
+            Ok(components[idx].len())
+        }
+    }
+
     fn test_vendor_uuid() -> Uuid {
         uuid!("fa6b4a53-d5ad-5fdf-be9d-e663e4d41ffe")
     }
@@ -802,6 +884,23 @@ mod tests {
 
     fn create_empty_components() -> &'static ByteSlice {
         (&[] as &[u8]).into()
+    }
+
+    const TWO_COMPONENTS: [u8; 7] = [0x82, 0x81, 0x41, 0x00, 0x81, 0x41, 0x01];
+
+    fn create_two_components() -> &'static ByteSlice {
+        (&TWO_COMPONENTS as &[u8]).into()
+    }
+
+    const COMPONENT_0: [u8; 3] = [0x81, 0x41, 0x00];
+    const COMPONENT_1: [u8; 3] = [0x81, 0x41, 0x01];
+
+    fn create_component_0() -> ComponentInfo<'static> {
+        ComponentInfo::new(Component::from_bytes(&COMPONENT_0), 0)
+    }
+
+    fn create_component_1() -> ComponentInfo<'static> {
+        ComponentInfo::new(Component::from_bytes(&COMPONENT_1), 1)
     }
 
     #[test]
@@ -934,6 +1033,46 @@ mod tests {
             res,
             CommandSequenceProperties::HasVendorCheck | CommandSequenceProperties::HasClassCheck
         );
+    }
+
+    #[test]
+    fn copy_component() {
+        let hooks = TestHooksMultiple::new();
+        // Set component 1 buf to known value
+        let mut components = hooks.components.get();
+        components[1] = [0x01, 0x02, 0x03, 0x04];
+        hooks.components.set(components);
+
+        let info = create_component_0();
+        let state = ManifestState::default();
+
+        // [override-parameters {source_component: 1}, copy, reporting_policy]
+        let cmd: &[u8] = &[0x84, 0x14, 0xA1, 0x16, 0x01, 0x16, 0x02];
+        let sequence = CommandSequenceExecutor::new(cmd.into(), create_two_components(), &hooks);
+        let res = sequence.process(state, &info);
+        assert!(res.is_ok());
+        // composant 0 doit contenir la valeur de composant 1
+        assert_eq!(hooks.components.get()[0], [0x01, 0x02, 0x03, 0x04]);
+    }
+
+    #[test]
+    fn swap_components() {
+        let hooks = TestHooksMultiple::new();
+        let mut components = hooks.components.get();
+        components[0] = [0xAA, 0xBB, 0xCC, 0xDD];
+        components[1] = [0x01, 0x02, 0x03, 0x04];
+        hooks.components.set(components);
+
+        let info = create_component_0();
+        let state = ManifestState::default();
+
+        // [override-parameters {source_component: 1}, swap, reporting_policy]
+        let cmd: &[u8] = &[0x84, 0x14, 0xA1, 0x16, 0x01, 0x18, 0x1F, 0x02];
+        let sequence = CommandSequenceExecutor::new(cmd.into(), create_two_components(), 0, &hooks);
+        let res = sequence.process(state, &info);
+        assert!(res.is_ok());
+        assert_eq!(hooks.components.get()[0], [0x01, 0x02, 0x03, 0x04]);
+        assert_eq!(hooks.components.get()[1], [0xAA, 0xBB, 0xCC, 0xDD]);
     }
 
     #[test]

--- a/src/command.rs
+++ b/src/command.rs
@@ -347,9 +347,7 @@ impl<'a, O: OperatingHooks> CommandSequenceExecutor<'a, O> {
             SuitCommand::RunSequence => Err(Error::UnsupportedCommand {
                 command: SuitCommand::RunSequence.into(),
             })?,
-            SuitCommand::Swap => Err(Error::UnsupportedCommand {
-                command: SuitCommand::RunSequence.into(),
-            })?,
+            SuitCommand::Swap => self.directive_swap(state, component_info, self.components)?,
             SuitCommand::TryEach => {
                 let mut argument = command.get_argument_cbor()?.clone();
                 self.try_each(state, component_info, &mut argument)?
@@ -605,6 +603,82 @@ impl<'a, O: OperatingHooks> CommandSequenceExecutor<'a, O> {
                         buf,
                     )?;
                 }
+                return Ok(());
+            }
+        }
+        Err(Error::InvalidSourceComponent {
+            identifier: source_index,
+        })
+    }
+
+    fn directive_swap(
+        &self,
+        state: &ManifestState,
+        component: &ComponentInfo,
+        components: &'a ByteSlice,
+    ) -> Result<(), Error> {
+        let Some(source_index) = state.source_component else {
+            return Err(Error::ParameterNotSet { position: 0 });
+        };
+        if source_index == component.index {
+            return Err(Error::SameSourceAndTarget {
+                identifier: source_index,
+            });
+        }
+        let mut decoder = Decoder::new(components);
+        for (idx, source) in ComponentIter::new(&mut decoder)?.enumerate() {
+            if (idx as u32) == source_index {
+                let source_component = source?;
+
+                if state.image_digest.is_some() && state.image_size.is_some() {
+                    // Check if data is different before copying
+                    if self.cond_image_match(state, component.component()).is_ok() {
+                        return Ok(());
+                    }
+
+                    // Avoid copy of corrupted image
+                    self.cond_image_match(state, &source_component)?;
+                }
+
+                let source_size = self.os_hooks.component_size(&source_component)?;
+
+                let mut read_source_buf = RwBuf::<O::ReadWriteBufferSize>::new().buf;
+                let mut read_target_buf = RwBuf::<O::ReadWriteBufferSize>::new().buf;
+
+                for offset in (0..source_size).step_by(read_source_buf.len()) {
+                    let diff = source_size.saturating_sub(offset);
+                    let read_size = if diff < read_source_buf.len() {
+                        diff
+                    } else {
+                        read_source_buf.len()
+                    };
+
+                    self.os_hooks.component_read(
+                        &source_component,
+                        state.component_slot,
+                        offset,
+                        &mut read_source_buf[0..read_size],
+                    )?;
+                    self.os_hooks.component_read(
+                        component.component(),
+                        state.component_slot,
+                        offset,
+                        &mut read_target_buf[0..read_size],
+                    )?;
+                    self.os_hooks.component_write(
+                        &source_component,
+                        state.component_slot,
+                        offset,
+                        &read_target_buf[0..read_size],
+                    )?;
+                    self.os_hooks.component_write(
+                        component.component(),
+                        state.component_slot,
+                        offset,
+                        &read_source_buf[0..read_size],
+                    )?;
+                }
+
                 return Ok(());
             }
         }

--- a/src/error.rs
+++ b/src/error.rs
@@ -39,6 +39,10 @@ pub enum Error {
     NoManifestObject,
     /// Parameter required for the condition is not set.
     ParameterNotSet(usize),
+    /// Source and target component are the same in the copy directive.
+    SameSourceAndTarget(u32),
+    /// Source component doesn't exists in the component list.
+    InvalidSourceComponent(u32),
     /// CBOR element type at location is unexpected.
     UnexpectedCbor(usize),
     /// CBOR array or map is of indefinite length where it is not allowed.
@@ -97,6 +101,18 @@ impl core::fmt::Display for Error {
             Self::NoManifestObject => write!(f, "no Manifest object in manifest"),
             Self::ParameterNotSet(n) => {
                 write!(f, "parameter required for condition at {n} not set")
+            }
+            Self::SameSourceAndTarget(n) => {
+                write!(
+                    f,
+                    "source component at index {n} is the same than target in copy directive"
+                )
+            }
+            Self::InvalidSourceComponent(n) => {
+                write!(
+                    f,
+                    "source component index {n} not found in the component list"
+                )
             }
             Self::UnexpectedCbor(pos) => write!(f, "unexpected CBOR found at {pos}"),
             Self::UnexpectedIndefiniteLength(n) => {

--- a/src/error.rs
+++ b/src/error.rs
@@ -58,6 +58,16 @@ pub enum Error {
         /// Position of the command for which the parameter is not set in the manifest.
         position: usize,
     },
+    /// Source and target component are the same in the copy directive.
+    SameSourceAndTarget {
+        /// Identifier of the components.
+        identifier: u32,
+    },
+    /// Source component doesn't exists in the component list.
+    InvalidSourceComponent {
+        /// Identifier of the invalid component.
+        identifier: u32,
+    },
     /// CBOR element type at location is unexpected.
     UnexpectedCbor {
         /// Position of the unexpected CBOR element.
@@ -161,6 +171,18 @@ impl core::fmt::Display for Error {
                 write!(
                     f,
                     "unexpected indefinite length cbor container at {position}"
+                )
+            }
+            Self::SameSourceAndTarget { identifier } => {
+                write!(
+                    f,
+                    "source component at index {identifier} is the same than target in copy directive"
+                )
+            }
+            Self::InvalidSourceComponent { identifier } => {
+                write!(
+                    f,
+                    "source component index {identifier} not found in the component list"
                 )
             }
             Self::UnsupportedCommand { command } => write!(f, "command {command} not supported"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -330,6 +330,15 @@ pub trait OperatingHooks {
     ) -> Result<(), Error> {
         Err(Error::UnsupportedCommand(SuitCommand::Fetch.into()))
     }
+
+    /// Swap the the payload between two component.
+    fn swap(
+        &self,
+        _component: &component::Component,
+        _other: &component::Component,
+    ) -> Result<(), Error> {
+        Err(Error::UnsupportedCommand(SuitCommand::Swap.into()))
+    }
 }
 
 impl<'a, S: AuthState> SuitManifest<'a, S> {

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -239,11 +239,12 @@ impl<'a> Manifest<'a, Authenticated> {
                     .map_err(|_| Error::UnexpectedCbor(self.decoder.position()))?;
                 let component_info = ComponentInfo::new(component, idx);
 
-                let common_sequence = CommandSequenceExecutor::new(common, os_hooks);
+                let common_sequence = CommandSequenceExecutor::new(common, components, os_hooks);
                 let state = common_sequence
                     .process(start_state.clone(), &component_info)
                     .map_err(|e| e.add_offset(common_offset))?;
-                let section = CommandSequenceExecutor::new(command_section.cbor, os_hooks);
+                let section =
+                    CommandSequenceExecutor::new(command_section.cbor, components, os_hooks);
                 section
                     .process(state, &component_info)
                     .map_err(|e| e.add_offset(command_section.offset))?;

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -185,11 +185,13 @@ impl<'a> Manifest<'a, Authenticated> {
             })?;
             let component_info = ComponentInfo::new(component, idx);
 
-            let state =
-                common
-                    .shared_sequence()
-                    .execute(start_state.clone(), &component_info, os_hooks)?;
-            command_section.execute(state, &component_info, os_hooks)?;
+            let state = common.shared_sequence().execute(
+                start_state.clone(),
+                &component_info,
+                common.components,
+                os_hooks,
+            )?;
+            command_section.execute(state, &component_info, common.components, os_hooks)?;
         }
         Ok(())
     }

--- a/src/manifeststate.rs
+++ b/src/manifeststate.rs
@@ -21,6 +21,7 @@ pub(crate) struct ManifestState<'a> {
     pub(crate) component_slot: Option<u64>,
     pub(crate) image_size: Option<usize>,
     pub(crate) uri: Option<&'a str>,
+    pub(crate) source_component: Option<u32>,
 }
 
 impl<'a> ManifestState<'a> {
@@ -114,6 +115,19 @@ impl<'a> ManifestState<'a> {
         Ok(())
     }
 
+    pub(crate) fn set_source_component(&mut self, source_component: u32) {
+        self.source_component = Some(source_component);
+    }
+
+    pub(crate) fn source_component_from_cbor(
+        &mut self,
+        decoder: &mut Decoder<'a>,
+    ) -> Result<(), Error> {
+        let source_component = decoder.u32()?;
+        self.set_source_component(source_component);
+        Ok(())
+    }
+
     pub(crate) fn update_parameter(&mut self, decoder: &mut Decoder<'a>) -> Result<(), Error> {
         let length = decoder.map()?;
         let length = length.ok_or(Error::UnexpectedIndefiniteLength(decoder.position()))?;
@@ -126,7 +140,7 @@ impl<'a> ManifestState<'a> {
                 SuitParameter::ComponentSlot => self.component_slot_from_cbor(decoder)?,
                 SuitParameter::ImageSize => self.image_size_from_cbor(decoder)?,
                 SuitParameter::Uri => self.uri_from_cbor(decoder)?,
-                SuitParameter::SourceComponent => todo!(),
+                SuitParameter::SourceComponent => self.source_component_from_cbor(decoder)?,
                 SuitParameter::DeviceId => self.device_id_from_cbor(decoder)?,
                 SuitParameter::Content => self.content_from_cbor(decoder)?,
                 param => return Err(Error::UnsupportedParameter(param.into())),
@@ -233,6 +247,17 @@ mod tests {
         params.update_parameter(&mut decoder).unwrap();
 
         assert_eq!(params.uri.unwrap(), uri);
+    }
+
+    #[test]
+    fn source_component() {
+        let source_component = 1;
+        let input = std::vec![0xA1, 0x16, 0x01];
+        let mut params = ManifestState::default();
+        let mut decoder = Decoder::new(&input);
+        params.update_parameter(&mut decoder).unwrap();
+
+        assert_eq!(params.source_component.unwrap(), source_component);
     }
 
     #[test]

--- a/src/manifeststate.rs
+++ b/src/manifeststate.rs
@@ -22,6 +22,7 @@ pub(crate) struct ManifestState<'a> {
     pub(crate) image_size: Option<usize>,
     pub(crate) uri: Option<&'a str>,
     pub(crate) invoke_args: Option<&'a ByteSlice>,
+    pub(crate) source_component: Option<u32>,
 }
 
 impl<'a> ManifestState<'a> {
@@ -125,6 +126,19 @@ impl<'a> ManifestState<'a> {
         Ok(())
     }
 
+    pub(crate) fn set_source_component(&mut self, source_component: u32) {
+        self.source_component = Some(source_component);
+    }
+
+    pub(crate) fn source_component_from_cbor(
+        &mut self,
+        decoder: &mut Decoder<'a>,
+    ) -> Result<(), Error> {
+        let source_component = decoder.u32()?;
+        self.set_source_component(source_component);
+        Ok(())
+    }
+
     pub(crate) fn update_parameter(&mut self, decoder: &mut Decoder<'a>) -> Result<(), Error> {
         let position = decoder.position();
         let length = decoder.map()?;
@@ -138,7 +152,7 @@ impl<'a> ManifestState<'a> {
                 SuitParameter::ComponentSlot => self.component_slot_from_cbor(decoder)?,
                 SuitParameter::ImageSize => self.image_size_from_cbor(decoder)?,
                 SuitParameter::Uri => self.uri_from_cbor(decoder)?,
-                SuitParameter::SourceComponent => todo!(),
+                SuitParameter::SourceComponent => self.source_component_from_cbor(decoder)?,
                 SuitParameter::DeviceId => self.device_id_from_cbor(decoder)?,
                 SuitParameter::Content => self.content_from_cbor(decoder)?,
                 SuitParameter::InvokeArgs => self.invoke_args_from_cbor(decoder)?,
@@ -262,8 +276,16 @@ mod tests {
         let mut params = ManifestState::default();
         let mut decoder = Decoder::new(&input);
         params.update_parameter(&mut decoder).unwrap();
-
         assert_eq!(params.invoke_args.unwrap().as_ref(), invoke_arg);
+    }
+
+    fn source_component() {
+        let source_component = 1;
+        let input = std::vec![0xA1, 0x16, 0x01];
+        let mut params = ManifestState::default();
+        let mut decoder = Decoder::new(&input);
+        params.update_parameter(&mut decoder).unwrap();
+        assert_eq!(params.source_component.unwrap(), source_component);
     }
 
     #[test]

--- a/src/operatinghooks.rs
+++ b/src/operatinghooks.rs
@@ -97,4 +97,11 @@ pub trait OperatingHooks {
             command: SuitCommand::Fetch.into(),
         })
     }
+
+    /// Swap the the payload between two component.
+    fn swap(&self, _component: &Component, _other: &Component) -> Result<(), Error> {
+        Err(Error::UnsupportedCommand {
+            command: SuitCommand::Swap.into(),
+        })
+    }
 }


### PR DESCRIPTION
Implements `suit-directive-copy` and `suit-directive-swap`.

**Changes:**
- `command.rs`: add `components: &'a ByteSlice` field to `CommandSequenceExecutor`  needed to resolve the source component index at execution time
- `command.rs`: implement `directive_copy` : copies source component to target chunk by chunk using `ReadWriteBufferSize` buffer, with optional digest optimizations (skip if target already matches, abort if source is corrupted)
- `command.rs`: implement `directive_swap` : default = OS implementation. When built in swap feature is enabled: swaps source and target components chunk by chunk using two `ReadWriteBufferSize` buffers
- `manifeststate.rs`: add `source_component` parameter with `set_source_component` and `source_component_from_cbor`
- `error.rs`: add `SameSourceAndTarget(u32)` and `InvalidSourceComponent(u32)` error variants

**Notes:**
- Both commands verify that source and target are not the same component
- `copy` implements the two optional digest optimizations from the spec (MAY)
- `swap` delegates size compatibility to `component_write`  no explicit size check since the spec doesn't require . 
- `swap` by default is relative to an **OS implementation** and the built-in version is feature gated. 

Related to #5 

!! Depends on #7