### PR TITLE
feat: Add soft-failure support and implement run-sequence (issue #5)

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -178,6 +178,34 @@ impl<'a, O: OperatingHooks> CommandSequenceExecutor<'a, O> {
         Err(Error::TryEachFail(decoder.position()))
     }
 
+    fn run_sequence(
+        &self,
+        state: &mut ManifestState<'a>,
+        component: &'a ComponentInfo<'a>,
+        decoder: &mut Decoder<'a>,
+    ) -> Result<(), Error> {
+        let seq = decoder.decode::<&ByteSlice>()?;
+        if seq.is_empty() {
+            return Ok(());
+        }
+
+        let sequence = CommandSequenceExecutor::new(seq, self.os_hooks);
+
+        let mut run_sequence_state = state.clone();
+        // A run sequence always start with soft failure set to false.
+        run_sequence_state.soft_failure = false;
+        run_sequence_state.enable_soft_failure_set();
+        let res = match sequence.process(run_sequence_state, component) {
+            Ok(new_state) => {
+                state.update_state_preserve_soft_failure(new_state);
+                Ok(())
+            }
+            Err(Error::SoftConditionFailure) => Ok(()),
+            Err(e) => return Err(e),
+        };
+        res
+    }
+
     fn enter_sequence(decoder: &mut Decoder) -> Result<u64, Error> {
         let length = decoder.array()?;
         let length = match length {
@@ -268,9 +296,9 @@ impl<'a, O: OperatingHooks> CommandSequenceExecutor<'a, O> {
 
             SuitCommand::Invoke => Err(Error::UnsupportedCommand(SuitCommand::Invoke.into()))?,
             SuitCommand::RunSequence => {
-                Err(Error::UnsupportedCommand(SuitCommand::RunSequence.into()))?
+                self.run_sequence(state, component, command.get_argument_cbor()?)
+                    .map_err(|e| e.add_offset(offset))?;
             }
-
             SuitCommand::Swap => Err(Error::UnsupportedCommand(SuitCommand::RunSequence.into()))?,
             SuitCommand::TryEach => {
                 self.try_each(state, component, command.get_argument_cbor()?)

--- a/src/command.rs
+++ b/src/command.rs
@@ -155,16 +155,25 @@ impl<'a, O: OperatingHooks> CommandSequenceExecutor<'a, O> {
             if seq.is_empty() {
                 return Ok(());
             }
+
             let try_sequence = CommandSequenceExecutor::new(seq, self.os_hooks);
-            let res = try_sequence.process(state.clone(), component);
-            if let Ok(res) = res {
-                *state = res;
-                return Ok(());
-            }
-            // Bail out on any error except the ConditionMatchFail
-            if !matches!(res, Err(Error::ConditionMatchFail(_))) {
-                return res.map(|_| ());
-            }
+
+            let mut try_sequence_state = state.clone();
+
+            // Soft Failure defaults to True in every Suit Command Sequence
+            // in the try each argument.
+            try_sequence_state.soft_failure = true;
+            try_sequence_state.enable_soft_failure_set();
+            match try_sequence.process(try_sequence_state, component) {
+                Ok(new_state) => {
+                    state.update_state_preserve_soft_failure(new_state);
+                    return Ok(());
+                }
+                Err(Error::SoftConditionFailure) => continue,
+                Err(e) => {
+                    return Err(e);
+                }
+            };
         }
         Err(Error::TryEachFail(decoder.position()))
     }
@@ -201,67 +210,81 @@ impl<'a, O: OperatingHooks> CommandSequenceExecutor<'a, O> {
                     }
                 }
             } else {
-                match command.command {
-                    SuitCommand::Unset => {
-                        return Err(Error::UnsupportedCommand(command.command.into()))
-                    }
-                    SuitCommand::Abort => return Err(Error::ConditionMatchFail(command.position)),
-                    SuitCommand::OverrideParameters => {
-                        state
-                            .update_parameter(command.get_argument_cbor()?)
-                            .map_err(|e| e.add_offset(command.get_argument_offset()))?;
-                    }
-                    SuitCommand::SetComponentIndex => {
-                        match_component = component
-                            .in_applylist(command.get_argument_cbor()?)
-                            .map_err(|e| e.add_offset(command.get_argument_offset()))?;
-                    }
-                    SuitCommand::CheckContent => {
-                        // byte by byte check
-                        self.cond_check_content(&state, component.component())?;
-                    }
-                    SuitCommand::ClassIdentifier => {
-                        self.cond_class_identifier(&state, component.component())?;
-                    }
-                    SuitCommand::ComponentSlot => {
-                        self.cond_component_slot(&state, component.component())?;
-                    }
-                    SuitCommand::Copy => Err(Error::UnsupportedCommand(SuitCommand::Copy.into()))?,
-                    SuitCommand::DeviceIdentifier => {
-                        self.cond_device_identifier(&state, component.component())?;
-                    }
-                    SuitCommand::Fetch => {
-                        self.directive_fetch(&state, component.component())?;
-                    }
-                    SuitCommand::ImageMatch => {
-                        // Digest check
-                        self.cond_image_match(&state, component.component())?;
-                    }
-
-                    SuitCommand::Invoke => {
-                        Err(Error::UnsupportedCommand(SuitCommand::Invoke.into()))?
-                    }
-                    SuitCommand::RunSequence => {
-                        Err(Error::UnsupportedCommand(SuitCommand::RunSequence.into()))?
-                    }
-                    SuitCommand::Swap => {
-                        Err(Error::UnsupportedCommand(SuitCommand::RunSequence.into()))?
-                    }
-                    SuitCommand::TryEach => {
-                        self.try_each(&mut state, component, command.get_argument_cbor()?)
-                            .map_err(|e| e.add_offset(command.get_argument_offset()))?;
-                    }
-                    SuitCommand::VendorIdentifier => {
-                        self.cond_vendor_identifier(&state, component.component())?;
-                    }
-                    SuitCommand::WriteContent => {
-                        self.directive_write(&state, component.component())?;
-                    }
-                    SuitCommand::Custom(_n) => todo!(),
-                }
+                self.execute_command(&mut command, &mut state, component, &mut match_component)
+                    .map_err(|e| {
+                        if state.soft_failure && e.is_condition_failure() {
+                            Error::SoftConditionFailure
+                        } else {
+                            e
+                        }
+                    })?;
             }
         }
         Ok(state)
+    }
+
+    fn execute_command(
+        &self,
+        command: &mut Command<'a>,
+        state: &mut ManifestState<'a>,
+        component: &'a ComponentInfo,
+        match_component: &mut bool,
+    ) -> Result<(), Error> {
+        let offset = command.get_argument_offset();
+        match command.command {
+            SuitCommand::Unset => return Err(Error::UnsupportedCommand(command.command.into())),
+            SuitCommand::Abort => return Err(Error::ConditionMatchFail(command.position)),
+            SuitCommand::OverrideParameters => {
+                state
+                    .update_parameter(command.get_argument_cbor()?)
+                    .map_err(|e| e.add_offset(offset))?;
+            }
+            SuitCommand::SetComponentIndex => {
+                *match_component = component
+                    .in_applylist(command.get_argument_cbor()?)
+                    .map_err(|e| e.add_offset(offset))?;
+            }
+            SuitCommand::CheckContent => {
+                // byte by byte check
+                self.cond_check_content(state, component.component())?;
+            }
+            SuitCommand::ClassIdentifier => {
+                self.cond_class_identifier(state, component.component())?;
+            }
+            SuitCommand::ComponentSlot => {
+                self.cond_component_slot(state, component.component())?;
+            }
+            SuitCommand::Copy => Err(Error::UnsupportedCommand(SuitCommand::Copy.into()))?,
+            SuitCommand::DeviceIdentifier => {
+                self.cond_device_identifier(state, component.component())?;
+            }
+            SuitCommand::Fetch => {
+                self.directive_fetch(state, component.component())?;
+            }
+            SuitCommand::ImageMatch => {
+                // Digest check
+                self.cond_image_match(state, component.component())?;
+            }
+
+            SuitCommand::Invoke => Err(Error::UnsupportedCommand(SuitCommand::Invoke.into()))?,
+            SuitCommand::RunSequence => {
+                Err(Error::UnsupportedCommand(SuitCommand::RunSequence.into()))?
+            }
+
+            SuitCommand::Swap => Err(Error::UnsupportedCommand(SuitCommand::RunSequence.into()))?,
+            SuitCommand::TryEach => {
+                self.try_each(state, component, command.get_argument_cbor()?)
+                    .map_err(|e| e.add_offset(offset))?;
+            }
+            SuitCommand::VendorIdentifier => {
+                self.cond_vendor_identifier(state, component.component())?;
+            }
+            SuitCommand::WriteContent => {
+                self.directive_write(state, component.component())?;
+            }
+            SuitCommand::Custom(_n) => todo!(),
+        }
+        Ok(())
     }
 
     fn cond_class_identifier(
@@ -700,5 +723,21 @@ mod tests {
         let sequence = CommandSequenceExecutor::new(input.into(), &hooks);
         let res = sequence.process(state.clone(), &info);
         assert_eq!(res, Ok(state));
+    }
+
+    #[test]
+    fn try_each_soft_failure_false() {
+        // Try each statement with override parameters on the soft failure
+        // to abort on next condition failure.
+        let input: &[u8] = &[
+            0x82, 0x0F, 0x82, 0x47, 0x84, 0x14, 0xA1, 0x0D, 0xF4, 0x0E, 0x01, 0x45, 0x82, 0x14,
+            0xA1, 0x05, 0x02,
+        ];
+        let hooks = create_test_hooks();
+        let info = create_test_component();
+        let state = ManifestState::default();
+        let sequence = CommandSequenceExecutor::new(input.into(), &hooks);
+        let res = sequence.process(state.clone(), &info).unwrap_err();
+        assert_eq!(res, Error::ConditionMatchFail(7));
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -19,12 +19,18 @@ pub enum Error {
     ConditionMatchFail(usize),
     /// SUIT Try Each command sequence failed every sequence.
     TryEachFail(usize),
+    /// SUIT Run Sequence failed.
+    RunSequenceFail(usize),
     /// Unexpected end of the CBOR input.
     EndOfInput,
     /// Authentication structure is not valid.
     InvalidAuthenticationStructure,
     /// Invalid command sequence.
     InvalidCommandSequence(usize),
+    /// SUIT parameter soft-failure set outside of a run-sequence or try-each context.
+    SoftFailureUnsettable(usize),
+    /// Condition failure in a soft-failure context — can be ignored by the caller
+    SoftConditionFailure,
     /// Invalid common section.
     InvalidCommonSection,
     /// No authentication object found inside the SUIT envelope.
@@ -62,11 +68,17 @@ impl Error {
         Error::UnsupportedDigestAlgo(value)
     }
 
+    pub(crate) fn is_condition_failure(&self) -> bool {
+        matches!(self, Error::ConditionMatchFail(_))
+    }
+
     /// Use to modify error position on bytes-string wrapped CBOR
     pub(crate) fn add_offset(self, offset: usize) -> Self {
         match self {
             Error::ConditionMatchFail(pos) => Error::ConditionMatchFail(pos + offset),
             Error::TryEachFail(pos) => Error::TryEachFail(pos + offset),
+            Error::RunSequenceFail(pos) => Error::RunSequenceFail(pos + offset),
+            Error::SoftFailureUnsettable(pos) => Error::SoftFailureUnsettable(pos + offset),
             Error::InvalidCommandSequence(pos) => Error::InvalidCommandSequence(pos + offset),
             Error::ParameterNotSet(pos) => Error::ParameterNotSet(pos + offset),
             Error::UnexpectedCbor(pos) => Error::UnexpectedCbor(pos + offset),
@@ -86,6 +98,11 @@ impl core::fmt::Display for Error {
             Self::CapacityError => write!(f, "string capacity exhausted"),
             Self::ConditionMatchFail(pos) => write!(f, "condition mismatch at {pos}"),
             Self::TryEachFail(pos) => write!(f, "try each sequence failed at {pos}"),
+            Self::RunSequenceFail(pos) => write!(f, "run sequence failed at {pos}"),
+            Self::SoftFailureUnsettable(pos) => write!(
+                f,
+                "soft failure set outside run sequence or try each sequence at {pos} "
+            ),
             Self::EndOfInput => write!(f, "end of CBOR input"),
             Self::InvalidAuthenticationStructure => write!(f, "invalide authentication structure"),
             Self::InvalidCommandSequence(n) => write!(f, "invalid command sequence at {n}"),
@@ -110,6 +127,7 @@ impl core::fmt::Display for Error {
             Self::UnsupportedManifestVersion => write!(f, "manifest version not supported"),
             Self::UnsupportedParameter(n) => write!(f, "parameter {n} not supported"),
             Self::Utf8Error(n) => write!(f, "unable to interpret bytes as string at {n}"),
+            Self::SoftConditionFailure => unreachable!(),
         }
     }
 }

--- a/src/manifeststate.rs
+++ b/src/manifeststate.rs
@@ -21,6 +21,8 @@ pub(crate) struct ManifestState<'a> {
     pub(crate) component_slot: Option<u64>,
     pub(crate) image_size: Option<usize>,
     pub(crate) uri: Option<&'a str>,
+    soft_failure_settable: bool,
+    pub(crate) soft_failure: bool,
 }
 
 impl<'a> ManifestState<'a> {
@@ -114,6 +116,43 @@ impl<'a> ManifestState<'a> {
         Ok(())
     }
 
+    pub(crate) fn enable_soft_failure_set(&mut self) {
+        self.soft_failure_settable = true;
+    }
+
+    pub(crate) fn disable_soft_failure_set(&mut self) {
+        self.soft_failure_settable = false;
+    }
+
+    /// Set the soft failure state. Setting outside of Try Each or Run Sequence should
+    /// led to an abortion.
+    pub(crate) fn set_soft_failure(&mut self, soft_failure: bool) -> Result<(), Error> {
+        if !self.soft_failure_settable {
+            return Err(Error::SoftFailureUnsettable(0));
+        }
+        self.soft_failure = soft_failure;
+        Ok(())
+    }
+
+    pub(crate) fn soft_failure_from_cbor(
+        &mut self,
+        decoder: &mut Decoder<'a>,
+    ) -> Result<(), Error> {
+        let soft_failure = decoder.bool()?;
+        self.set_soft_failure(soft_failure)?;
+        Ok(())
+    }
+
+    /// Update the state after a Run Sequence or a Try Each Sequence termination
+    /// without updating [ManifestState::soft_failure] since it is scoped to a run sequence.
+    pub(crate) fn update_state_preserve_soft_failure(&mut self, new_state: ManifestState<'a>) {
+        let soft_failure = self.soft_failure;
+        let soft_failure_settable = self.soft_failure_settable;
+        *self = new_state;
+        self.soft_failure = soft_failure;
+        self.soft_failure_settable = soft_failure_settable;
+    }
+
     pub(crate) fn update_parameter(&mut self, decoder: &mut Decoder<'a>) -> Result<(), Error> {
         let length = decoder.map()?;
         let length = length.ok_or(Error::UnexpectedIndefiniteLength(decoder.position()))?;
@@ -129,6 +168,7 @@ impl<'a> ManifestState<'a> {
                 SuitParameter::SourceComponent => todo!(),
                 SuitParameter::DeviceId => self.device_id_from_cbor(decoder)?,
                 SuitParameter::Content => self.content_from_cbor(decoder)?,
+                SuitParameter::SoftFailure => self.soft_failure_from_cbor(decoder)?,
                 param => return Err(Error::UnsupportedParameter(param.into())),
             };
         }
@@ -233,6 +273,42 @@ mod tests {
         params.update_parameter(&mut decoder).unwrap();
 
         assert_eq!(params.uri.unwrap(), uri);
+    }
+
+    #[test]
+    fn soft_failure() {
+        let soft_failure = true;
+        let input = std::vec![0xA1, 0x0D, 0xF5];
+        let mut params = ManifestState::default();
+        let mut decoder = Decoder::new(&input);
+        params.enable_soft_failure_set();
+        params.update_parameter(&mut decoder).unwrap();
+
+        assert_eq!(params.soft_failure, soft_failure);
+    }
+
+    #[test]
+    fn soft_failure_fail() {
+        let input = std::vec![0xA1, 0x0D, 0xF5];
+        let mut params = ManifestState::default();
+        let mut decoder = Decoder::new(&input);
+        let res = params.update_parameter(&mut decoder).unwrap_err();
+
+        assert_eq!(res, Error::SoftFailureUnsettable(0));
+    }
+
+    #[test]
+    fn update_state_preserve_soft_failure() {
+        let mut initial_state = ManifestState::default();
+        let mut new_state = initial_state.clone();
+        new_state.soft_failure = true;
+        new_state.soft_failure_settable = true;
+        new_state.component_slot = Some(1);
+
+        initial_state.update_state_preserve_soft_failure(new_state);
+        assert!(!initial_state.soft_failure);
+        assert!(!initial_state.soft_failure_settable);
+        assert_eq!(initial_state.component_slot, Some(1));
     }
 
     #[test]


### PR DESCRIPTION

Implements `suit-directive-run-sequence` and improves `suit-directive-try-each` with proper soft-failure handling per the SUIT spec.

**Changes:**
- `manifeststate.rs`: add `soft_failure` and `soft_failure_settable` fields with `enable_soft_failure_set`, `disable_soft_failure_set`, `set_soft_failure` and `update_state_preserve_soft_failure`
- `command.rs`: refactor `process` to use `execute_command` helper allows soft-failure error handling at the command level
- `command.rs`: implement `run_sequence` executes a bstr-wrapped sub-sequence with `soft_failure = false` by default; condition failures are absorbed if `soft_failure = true`
- `command.rs`: fix `try_each`  properly initializes `soft_failure = true` per sequence, handles directive failures as fatal and condition failures as continuable
- `error.rs`: add `SoftConditionFailure` and `SoftFailureUnsettable` variants

**Notes:**
- `soft_failure` is scoped to each sub-sequence  it reverts to its prior value after `run_sequence` or `try_each` via `update_state_preserve_soft_failure`
- Setting `soft_failure` outside of a `run_sequence` or `try_each` context returns `SoftFailureUnsettable`

Related to #5 

!! Depends on #7 