### PR TITLE
ci: add simple CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: cargo fmt --all -- --check
-      - run: cargo clippy --all-targets --all-features -- -D warnings
-      - run: cargo build --all-targets --all-features
-      - run: cargo test --all-targets --all-features
+
+      - name: Install Prek (and taplo)
+        run: |
+          pip install --user prek
+          cargo install taplo-cli
+
+      - name: Run pre commit hooks
+        run: prek run --all-files --show-diff-on-failure --color always --hook-stage manual
+
+      - name: Build project
+        run: cargo build --all-targets --all-features
+
+      - name: Run tests
+        run: cargo test --all-targets --all-features

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: CI
+on:
+  push:
+  pull_request:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build_and_test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: cargo fmt --all -- --check
+      - run: cargo clippy --all-targets --all-features -- -D warnings
+      - run: cargo build --all-targets --all-features
+      - run: cargo test --all-targets --all-features

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -187,11 +187,8 @@
 //! [suit-rfc]: https://datatracker.ietf.org/doc/html/draft-ietf-suit-manifest-34
 use core::marker::PhantomData;
 
-use generic_array::ArrayLength;
 use minicbor::bytes::ByteSlice;
 use minicbor::decode::Decoder;
-
-use uuid::Uuid;
 
 pub mod auth;
 mod cbor;


### PR DESCRIPTION
Adds a simple CI pipeline using GitHub Actions.

**Changes:**
`.github/workflows/ci.yml`: implement simple CI to check formatting using `cargo fmt`, check linting using `cargo clippy`, build the project and run tests
`src/lib.rs`: remove unused imports to prevent linting check in CI from failing

**Notes:**
- The workflow is triggered on pushes and pull requests
- The pipeline will fail fast if formatting or linting checks do not pass
- Linting is configured to deny warnings 