### PR TITLE
fix: return error from ComponentIter to prevent infinite loop on malformed manifest

### DIFF
--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -178,19 +178,18 @@ impl<'a> Manifest<'a, Authenticated> {
             .map_err(|e| e.add_offset(common.component_offset))?
             .enumerate()
         {
-            if let Ok(component) = component {
-                let idx = idx.try_into().map_err(|_| Error::UnexpectedCbor {
-                    position: self.decoder.position(),
-                })?;
-                let component_info = ComponentInfo::new(component, idx);
+            let component = component.map_err(|e| e.add_offset(common.component_offset))?;
 
-                let state = common.shared_sequence().execute(
-                    start_state.clone(),
-                    &component_info,
-                    os_hooks,
-                )?;
-                command_section.execute(state, &component_info, os_hooks)?;
-            }
+            let idx = idx.try_into().map_err(|_| Error::UnexpectedCbor {
+                position: self.decoder.position(),
+            })?;
+            let component_info = ComponentInfo::new(component, idx);
+
+            let state =
+                common
+                    .shared_sequence()
+                    .execute(start_state.clone(), &component_info, os_hooks)?;
+            command_section.execute(state, &component_info, os_hooks)?;
         }
         Ok(())
     }


### PR DESCRIPTION
Closes #16 

Fixes the function `manifest.execute_invoke()` getting stuck in an infinite loop when trying to parse invalid CBOR. Errors from `ComponentIter` were ignored and the loop tried to iterate further without advancing.

**Changes**:
- `src/manifest.rs`: change function `manifest.execute_invoke()` to further return an Error returned by `ComponentIter`