### PR TITLE
Add integrated payload support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ openssl = "0.10.77"
 
 [features]
 default = ["sha384", "sha512", "shake128", "shake256"]
+integrated-payload = []
 sha384 = []
 sha512 = []
 shake128 = ["dep:sha3"]

--- a/examples/minimal/src/main.rs
+++ b/examples/minimal/src/main.rs
@@ -162,7 +162,7 @@ fn main() -> Result<(), Box<dyn std::error::Error + 'static>> {
     println!("Verified manifest signature");
     let envelope = suit.envelope()?;
     let manifest = envelope.manifest()?;
-    manifest.execute_payload_installation(&hooks)?;
+    manifest.execute_payload_installation(&hooks, &envelope)?;
     let storage = hooks.storage.take();
     println!("Storage now contains: {:02x?}", storage);
     Ok(())

--- a/src/command.rs
+++ b/src/command.rs
@@ -13,7 +13,7 @@ use crate::consts::SuitCommand;
 use crate::error::Error;
 use crate::manifeststate::ManifestState;
 use crate::report::ReportingPolicy;
-use crate::OperatingHooks;
+use crate::{Authenticated, Envelope, OperatingHooks};
 
 bitflags! {
     #[derive(Copy, Clone, Debug, PartialEq, Default)]
@@ -175,10 +175,11 @@ impl<'a> CommandSequence<'a> {
         state: ManifestState<'a>,
         component_info: &'a ComponentInfo<'a>,
         os_hooks: &'a impl OperatingHooks,
+        envelope: &Envelope<'a, Authenticated>
     ) -> Result<ManifestState<'a>, Error> {
         let executor = CommandSequenceExecutor::new(self.sequence, self.offset, os_hooks);
         executor
-            .process(state, component_info)
+            .process(state, component_info, envelope)
             .map_err(|e| e.add_offset(self.offset))
     }
 
@@ -246,6 +247,7 @@ impl<'a, O: OperatingHooks> CommandSequenceExecutor<'a, O> {
         state: &mut ManifestState<'a>,
         component_info: &'a ComponentInfo<'a>,
         decoder: &mut Decoder<'a>,
+        envelope: &Envelope<'a, Authenticated>,
     ) -> Result<(), Error> {
         let mut err_position = 0;
         let input = decoder.input(); // used for getting the position of the error
@@ -258,6 +260,7 @@ impl<'a, O: OperatingHooks> CommandSequenceExecutor<'a, O> {
                 state.clone(),
                 component_info,
                 self.os_hooks,
+                envelope,
             );
             match res {
                 Ok(res) => {
@@ -288,6 +291,7 @@ impl<'a, O: OperatingHooks> CommandSequenceExecutor<'a, O> {
         component_info: &'a ComponentInfo<'a>,
         match_component: &mut bool,
         mut command: Command<'a>,
+        envelope: &Envelope<'a, Authenticated>,
     ) -> Result<(), Error> {
         let component = component_info.component();
         let argument_offset = command.get_argument_offset();
@@ -307,6 +311,13 @@ impl<'a, O: OperatingHooks> CommandSequenceExecutor<'a, O> {
                 state
                     .update_parameter(&mut argument)
                     .map_err(|e| e.add_offset(argument_offset))?;
+
+                #[cfg(feature = "integrated-payload")]
+                if state.payload.is_none() {
+                    if let Some(uri) = state.uri {
+                        state.set_payload(envelope.integrated_payload(uri)?);
+                    }
+                }
             }
             SuitCommand::SetComponentIndex => {
                 *match_component = component_info.in_applylist(command.get_argument_cbor()?)?;
@@ -343,7 +354,7 @@ impl<'a, O: OperatingHooks> CommandSequenceExecutor<'a, O> {
             })?,
             SuitCommand::TryEach => {
                 let mut argument = command.get_argument_cbor()?.clone();
-                self.try_each(state, component_info, &mut argument)?
+                self.try_each(state, component_info, &mut argument, envelope)?
             }
             SuitCommand::VendorIdentifier => {
                 self.cond_vendor_identifier(state, component)?;
@@ -360,6 +371,7 @@ impl<'a, O: OperatingHooks> CommandSequenceExecutor<'a, O> {
         &self,
         mut state: ManifestState<'a>,
         component_info: &'a ComponentInfo<'a>,
+        envelope: &Envelope<'a, Authenticated>,
     ) -> Result<ManifestState<'a>, Error> {
         let mut match_component = true;
         for command in CommandSequenceIterator::new(self.command_sequence, self.offset)? {
@@ -378,7 +390,7 @@ impl<'a, O: OperatingHooks> CommandSequenceExecutor<'a, O> {
                     }
                 }
             } else {
-                self.process_command(&mut state, component_info, &mut match_component, command)
+                self.process_command(&mut state, component_info, &mut match_component, command, envelope)
                     .map_err(|e| e.add_offset(position))?;
             }
         }
@@ -524,6 +536,17 @@ impl<'a, O: OperatingHooks> CommandSequenceExecutor<'a, O> {
     }
 
     fn directive_fetch(&self, state: &ManifestState, component: &Component) -> Result<(), Error> {
+        #[cfg(feature = "integrated-payload")]
+        return self.os_hooks.fetch(
+            component,
+            state.component_slot,
+            state
+                .payload
+                .ok_or(Error::NoIntegratedPayload)?
+                .as_ref(),
+        );
+
+        #[cfg(not(feature = "integrated-payload"))]
         if let Some(uri) = state.uri {
             self.os_hooks.fetch(component, state.component_slot, uri)
         } else {
@@ -661,7 +684,7 @@ mod tests {
         let info = create_test_component();
         let sequence = CommandSequenceExecutor::new(input.into(), 0, &hooks);
         let state = ManifestState::default();
-        let res = sequence.process(state, &info).unwrap_err();
+        let res = sequence.process(state, &info, &Envelope { decoder: Decoder::new(&[]), phantom: crate::PhantomData }).unwrap_err();
         assert_eq!(res, Error::InvalidCommandSequence { position: 0 });
 
         let sequence = CommandSequence::new(input.into(), 0);
@@ -678,7 +701,7 @@ mod tests {
         let info = create_test_component();
         let sequence = CommandSequenceExecutor::new(input.into(), 0, &hooks);
         let state = ManifestState::default();
-        let res = sequence.process(state, &info).unwrap_err();
+        let res = sequence.process(state, &info, &Envelope { decoder: Decoder::new(&[]), phantom: crate::PhantomData }).unwrap_err();
         assert_eq!(res, Error::InvalidCommandSequence { position: 0 });
 
         let sequence = CommandSequence::new(input.into(), 0);
@@ -695,7 +718,7 @@ mod tests {
         let info = create_test_component();
         let sequence = CommandSequenceExecutor::new(input.into(), 0, &hooks);
         let state = ManifestState::default();
-        let res = sequence.process(state, &info).unwrap_err();
+        let res = sequence.process(state, &info, &Envelope { decoder: Decoder::new(&[]), phantom: crate::PhantomData }).unwrap_err();
         assert_eq!(res, Error::UnsupportedCommand { command: 0 });
 
         let sequence = CommandSequence::new(input.into(), 0);
@@ -712,7 +735,7 @@ mod tests {
         let info = create_test_component();
         let sequence = CommandSequenceExecutor::new(input.into(), 0, &hooks);
 
-        let res = sequence.process(state, &info).unwrap();
+        let res = sequence.process(state, &info, &Envelope { decoder: Decoder::new(&[]), phantom: crate::PhantomData }).unwrap();
         assert_eq!(res.component_slot, None);
 
         let sequence = CommandSequence::new(input.into(), 0);
@@ -729,7 +752,7 @@ mod tests {
         let info = create_test_component();
         let sequence = CommandSequenceExecutor::new(input.into(), 0, &hooks);
 
-        let res = sequence.process(state, &info).unwrap_err();
+        let res = sequence.process(state, &info, &Envelope { decoder: Decoder::new(&[]), phantom: crate::PhantomData }).unwrap_err();
         assert_eq!(res, Error::ParameterNotSet { position: 1 });
 
         let sequence = CommandSequence::new(input.into(), 0);
@@ -755,7 +778,7 @@ mod tests {
         let mut state = ManifestState::default();
         let info = create_test_component();
 
-        let res = sequence.process(state.clone(), &info);
+        let res = sequence.process(state.clone(), &info, &Envelope { decoder: Decoder::new(&[]), phantom: crate::PhantomData });
 
         let digest_bytes: &[u8] = &std::vec![
             0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd,
@@ -795,7 +818,7 @@ mod tests {
         let info = create_test_component();
 
         let sequence = CommandSequenceExecutor::new(input.into(), 0, &hooks);
-        let res = sequence.process(state, &info);
+        let res = sequence.process(state, &info, &Envelope { decoder: Decoder::new(&[]), phantom: crate::PhantomData });
         assert!(res.is_ok());
 
         let sequence = CommandSequence::new(input.into(), 0);
@@ -821,7 +844,7 @@ mod tests {
 
         let state = ManifestState::default();
         let sequence = CommandSequenceExecutor::new(input.into(), 0, &hooks);
-        let res = sequence.process(state, &info).unwrap();
+        let res = sequence.process(state, &info, &Envelope { decoder: Decoder::new(&[]), phantom: crate::PhantomData }).unwrap();
         assert_eq!(res.component_slot, Some(2));
 
         let sequence = CommandSequence::new(input.into(), 0);
@@ -838,14 +861,14 @@ mod tests {
 
         let state = ManifestState::default();
         let sequence = CommandSequenceExecutor::new(input.into(), 0, &hooks);
-        let res = sequence.process(state, &info).unwrap_err();
+        let res = sequence.process(state, &info, &Envelope { decoder: Decoder::new(&[]), phantom: crate::PhantomData }).unwrap_err();
         assert_eq!(res, Error::TryEachFail { position: 5 });
 
         let input: &[u8] =
             &std::vec![0x82, 0x0F, 0x82, 0x43, 0x82, 0x0E, 0x05, 0x43, 0x82, 0x0E, 0x05];
         let state = ManifestState::default();
         let sequence = CommandSequenceExecutor::new(input.into(), 0, &hooks);
-        let res = sequence.process(state, &info).unwrap_err();
+        let res = sequence.process(state, &info, &Envelope { decoder: Decoder::new(&[]), phantom: crate::PhantomData }).unwrap_err();
         assert_eq!(res, Error::TryEachFail { position: 9 });
     }
 
@@ -860,7 +883,7 @@ mod tests {
 
         let state = ManifestState::default();
         let sequence = CommandSequenceExecutor::new(input.into(), 0, &hooks);
-        let res = sequence.process(state, &info).unwrap_err();
+        let res = sequence.process(state, &info, &Envelope { decoder: Decoder::new(&[]), phantom: crate::PhantomData }).unwrap_err();
         assert_eq!(res, Error::UnsupportedParameter { parameter: 0 });
     }
 
@@ -874,7 +897,7 @@ mod tests {
 
         let state = ManifestState::default();
         let sequence = CommandSequenceExecutor::new(input.into(), 0, &hooks);
-        let res = sequence.process(state, &info).unwrap();
+        let res = sequence.process(state, &info, &Envelope { decoder: Decoder::new(&[]), phantom: crate::PhantomData }).unwrap();
         assert_eq!(res.component_slot, Some(2));
     }
 
@@ -886,7 +909,7 @@ mod tests {
 
         let state = ManifestState::default();
         let sequence = CommandSequenceExecutor::new(input.into(), 0, &hooks);
-        let res = sequence.process(state.clone(), &info);
+        let res = sequence.process(state.clone(), &info, &Envelope { decoder: Decoder::new(&[]), phantom: crate::PhantomData });
         assert_eq!(res, Ok(state));
 
         let sequence = CommandSequence::new(input.into(), 0);

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -19,7 +19,7 @@ pub const SUIT_COMMAND_SECTIONS: [Manifest; 5] = [
 /// All elements are bstr wrapped.
 ///
 /// See <https://datatracker.ietf.org/doc/html/draft-ietf-suit-manifest-34#name-suit-envelope-elements>
-#[derive(Copy, Clone, Debug, num_enum::IntoPrimitive)]
+#[derive(Copy, Clone, PartialEq, Debug, num_enum::IntoPrimitive, num_enum::TryFromPrimitive)]
 #[non_exhaustive]
 #[repr(i16)]
 pub enum SuitEnvelope {

--- a/src/error.rs
+++ b/src/error.rs
@@ -47,6 +47,9 @@ pub enum Error {
     },
     /// No component list inside the SUIT common section
     NoComponentList,
+    #[cfg(feature = "integrated-payload")]
+    /// No integrated payload found inside the SUIT envelope.
+    NoIntegratedPayload,
     /// No manifest object found inside the SUIT envelope.
     NoManifestObject,
     /// No manifest encoding version found inside the manifest object.
@@ -150,6 +153,8 @@ impl core::fmt::Display for Error {
                 write!(f, "no command sequence {section} found in manifest")
             }
             Self::NoComponentList => write!(f, "no component list found in manifest"),
+            #[cfg(feature = "integrated-payload")]
+            Self::NoIntegratedPayload => write!(f, "no integrated payload found in envelope"),
             Self::NoManifestObject => write!(f, "no Manifest object in manifest"),
             Self::NoManifestVersion => write!(f, "no Manifest version in manifest"),
             Self::NoSequenceNumber => write!(f, "no Manifest sequence number in manifest"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -273,7 +273,7 @@ impl<'a> SuitManifest<'a, New> {
         let envelope = self.envelope()?;
         // Consists of a bstr wrapped digest + *bstr wrapped auth blocks
         let manifest = envelope.get_object_wrapped(SuitEnvelope::Manifest)?;
-        let auth_object = envelope.get_object(SuitEnvelope::Authentication)?;
+        let auth_object = envelope.get_object(SuitEnvelope::Authentication.into())?;
 
         match (auth_object, manifest) {
             (None, _) => Err(Error::NoAuthObject),
@@ -292,13 +292,45 @@ impl<'a> SuitManifest<'a, New> {
 
 impl<'a> SuitManifest<'a, Authenticated> {}
 
+#[derive(PartialEq)]
+enum SearchKey<'a> {
+    Integer(SuitEnvelope),
+    Uri(&'a str),
+}
+
+impl<'a> From<SuitEnvelope> for SearchKey<'a> {
+    fn from(env: SuitEnvelope) -> Self {
+        SearchKey::Integer(env)
+    }
+}
+
+impl<'a, C> minicbor::Decode<'a, C> for SearchKey<'a> {
+    fn decode(d: &mut Decoder<'a>, _ctx: &mut C) -> Result<Self, minicbor::decode::Error> {
+        match d.datatype()? {
+            minicbor::data::Type::U8
+            | minicbor::data::Type::U16
+            | minicbor::data::Type::I8
+            | minicbor::data::Type::I16 => {
+                let val = d.i16()?;
+                let envelope = SuitEnvelope::try_from(val).map_err(|_| {
+                    minicbor::decode::Error::message("Unknown SuitEnvelope integer tag")
+                })?;
+
+                Ok(SearchKey::Integer(envelope))
+            }
+            minicbor::data::Type::String => Ok(SearchKey::Uri(d.str()?)),
+            ty => Err(minicbor::decode::Error::type_mismatch(ty)),
+        }
+    }
+}
+
 impl<'a, S: AuthState> Envelope<'a, S> {
-    fn get_object(&self, search_key: SuitEnvelope) -> Result<Option<&'a ByteSlice>, Error> {
+    fn get_object(&self, search_key: SearchKey) -> Result<Option<&'a ByteSlice>, Error> {
         let mut decoder = self.decoder.clone();
         decoder
-            .map_iter::<i16, &ByteSlice>()?
+            .map_iter::<SearchKey, &ByteSlice>()?
             .find_map(|item| match item {
-                Ok((key, item)) if key == search_key.into() => Some(Ok(item)),
+                Ok((key, item)) if key == search_key => Some(Ok(item)),
                 Err(e) => Some(Err(e.into())),
                 _ => None,
             })
@@ -325,7 +357,7 @@ impl<'a, S: AuthState> Envelope<'a, S> {
     ///
     /// Returns a reference to a byte slice containing the CBOR-encoded authentication object.
     pub fn auth_object(&self) -> Result<&'a ByteSlice, Error> {
-        let auth_object = self.get_object(SuitEnvelope::Authentication)?;
+        let auth_object = self.get_object(SuitEnvelope::Authentication.into())?;
         auth_object.ok_or(Error::NoAuthObject)
     }
 
@@ -335,7 +367,7 @@ impl<'a, S: AuthState> Envelope<'a, S> {
     ///
     /// See [`Envelope::manifest`] for retrieving a [`manifest::Manifest`] to operate on the manifest.
     pub fn manifest_bytes(&self) -> Result<&'a ByteSlice, Error> {
-        let manifest_object = self.get_object(SuitEnvelope::Manifest)?;
+        let manifest_object = self.get_object(SuitEnvelope::Manifest.into())?;
         manifest_object.ok_or(Error::NoManifestObject)
     }
 
@@ -343,6 +375,17 @@ impl<'a, S: AuthState> Envelope<'a, S> {
     pub fn manifest(&self) -> Result<Manifest<'a, S>, Error> {
         let manifest_bytes = self.manifest_bytes()?;
         Ok(Manifest::<S>::from_bytes(manifest_bytes))
+    }
+
+    /// Retrieve the payload.
+    #[cfg(feature = "integrated-payload")]
+    pub fn integrated_payload(&self, uri: &str) -> Result<&'a ByteSlice, Error> {
+        if let Ok(Some(payload)) = self.get_object(crate::SearchKey::Uri(uri)) {
+            Ok(payload)
+        }
+        else {
+            Err(Error::NoIntegratedPayload)
+        }
     }
 }
 

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -10,7 +10,7 @@ use crate::command::CommandSequence;
 use crate::component::{ComponentInfo, ComponentIter};
 use crate::error::Error;
 use crate::manifeststate::ManifestState;
-use crate::{AuthState, Authenticated, OperatingHooks};
+use crate::{AuthState, Authenticated, Envelope, OperatingHooks};
 
 /// Inner SUIT manifest.
 #[derive(Debug, Clone)]
@@ -164,6 +164,7 @@ impl<'a> Manifest<'a, Authenticated> {
         &self,
         os_hooks: &impl OperatingHooks,
         section: crate::consts::Manifest,
+        envelope: &'a crate::Envelope<'a, Authenticated>,
     ) -> Result<(), Error> {
         let start_state = ManifestState::default();
         let command_section =
@@ -188,8 +189,9 @@ impl<'a> Manifest<'a, Authenticated> {
                     start_state.clone(),
                     &component_info,
                     os_hooks,
+                    envelope
                 )?;
-                command_section.execute(state, &component_info, os_hooks)?;
+                command_section.execute(state, &component_info, os_hooks, envelope)?;
             }
         }
         Ok(())
@@ -199,8 +201,8 @@ impl<'a> Manifest<'a, Authenticated> {
     ///
     /// The command sequence in the common section is executed before the command sequence in the
     /// payload fetch is executed.
-    pub fn execute_payload_fetch(&self, os_hooks: &impl OperatingHooks) -> Result<(), Error> {
-        self.execute_section_with_common(os_hooks, crate::consts::Manifest::PayloadFetch)
+    pub fn execute_payload_fetch(&self, os_hooks: &impl OperatingHooks, envelope: &Envelope<'a, Authenticated>) -> Result<(), Error> {
+        self.execute_section_with_common(os_hooks, crate::consts::Manifest::PayloadFetch, envelope)
     }
 
     /// Execute the command sequence in the payload installation section.
@@ -210,38 +212,39 @@ impl<'a> Manifest<'a, Authenticated> {
     pub fn execute_payload_installation(
         &self,
         os_hooks: &impl OperatingHooks,
+        envelope: &Envelope<'a, Authenticated>,
     ) -> Result<(), Error> {
-        self.execute_section_with_common(os_hooks, crate::consts::Manifest::PayloadInstallation)
+        self.execute_section_with_common(os_hooks, crate::consts::Manifest::PayloadInstallation, envelope)
     }
 
     /// Execute the command sequence in the image validation section.
     ///
     /// The command sequence in the common section is executed before the command sequence in the
     /// image validation is executed.
-    pub fn execute_image_validation(&self, os_hooks: &impl OperatingHooks) -> Result<(), Error> {
-        self.execute_section_with_common(os_hooks, crate::consts::Manifest::ImageValidation)
+    pub fn execute_image_validation(&self, os_hooks: &impl OperatingHooks, envelope: &Envelope<'a, Authenticated>) -> Result<(), Error> {
+        self.execute_section_with_common(os_hooks, crate::consts::Manifest::ImageValidation, envelope)
     }
 
     /// Execute the command sequence in the image loading section.
     ///
     /// The command sequence in the common section is executed before the command sequence in the
     /// image loading is executed.
-    pub fn execute_image_loading(&self, os_hooks: &impl OperatingHooks) -> Result<(), Error> {
-        self.execute_section_with_common(os_hooks, crate::consts::Manifest::ImageLoading)
+    pub fn execute_image_loading(&self, os_hooks: &impl OperatingHooks, envelope: &Envelope<'a, Authenticated>) -> Result<(), Error> {
+        self.execute_section_with_common(os_hooks, crate::consts::Manifest::ImageLoading, envelope)
     }
 
     /// Execute the command sequence in the image loading section.
     ///
     /// The command sequence in the common section is executed before the command sequence in the
     /// invoke is executed.
-    pub fn execute_invoke(&self, os_hooks: &impl OperatingHooks) -> Result<(), Error> {
-        self.execute_section_with_common(os_hooks, crate::consts::Manifest::ImageInvocation)
+    pub fn execute_invoke(&self, os_hooks: &impl OperatingHooks, envelope: &Envelope<'a, Authenticated>) -> Result<(), Error> {
+        self.execute_section_with_common(os_hooks, crate::consts::Manifest::ImageInvocation, envelope)
     }
 
     /// Execute all command sequences in the manifest.
-    pub fn execute_full(&self, os_hooks: &impl OperatingHooks) -> Result<(), Error> {
+    pub fn execute_full(&self, os_hooks: &impl OperatingHooks, envelope: &Envelope<'a, Authenticated>) -> Result<(), Error> {
         for section in crate::consts::SUIT_COMMAND_SECTIONS {
-            let res = self.execute_section_with_common(os_hooks, section);
+            let res = self.execute_section_with_common(os_hooks, section, envelope);
             // Ignore NoCommandSequence errors
             if res.is_err_and(|e| !matches!(e, Error::NoCommandSection { .. })) {
                 return res;

--- a/src/manifeststate.rs
+++ b/src/manifeststate.rs
@@ -21,6 +21,8 @@ pub(crate) struct ManifestState<'a> {
     pub(crate) component_slot: Option<u64>,
     pub(crate) image_size: Option<usize>,
     pub(crate) uri: Option<&'a str>,
+    #[cfg(feature = "integrated-payload")]
+    pub(crate) payload: Option<&'a ByteSlice>,
 }
 
 impl<'a> ManifestState<'a> {
@@ -111,6 +113,17 @@ impl<'a> ManifestState<'a> {
     pub(crate) fn uri_from_cbor(&mut self, decoder: &mut Decoder<'a>) -> Result<(), Error> {
         let uri = decoder.str()?;
         self.set_uri(uri);
+        Ok(())
+    }
+
+    #[cfg(feature = "integrated-payload")]
+    pub(crate) fn set_payload(&mut self, payload: &'a ByteSlice) {
+        self.payload = Some(payload);
+    }
+
+    #[cfg(feature = "integrated-payload")]
+    pub(crate) fn payload_from_cbor(&mut self, decoder: &mut Decoder<'a>) -> Result<(), Error> {
+        self.set_payload(decoder.decode()?);
         Ok(())
     }
 

--- a/src/operatinghooks.rs
+++ b/src/operatinghooks.rs
@@ -80,8 +80,22 @@ pub trait OperatingHooks {
         self.component_capacity(component).map(|_| ())
     }
 
+    #[cfg(not(feature = "integrated-payload"))]
     /// Retrieve the payload from the url and store it in the component.
     fn fetch(&self, _component: &Component, _slot: Option<u64>, _uri: &str) -> Result<(), Error> {
+        Err(Error::UnsupportedCommand {
+            command: SuitCommand::Fetch.into(),
+        })
+    }
+
+    #[cfg(feature = "integrated-payload")]
+    /// Store the integrated payload in the component.
+    fn fetch(
+        &self,
+        _component: &Component,
+        _slot: Option<u64>,
+        _payload: &[u8],
+    ) -> Result<(), Error> {
         Err(Error::UnsupportedCommand {
             command: SuitCommand::Fetch.into(),
         })


### PR DESCRIPTION
This PR adds support for SUIT's [integrated payloads](https://datatracker.ietf.org/doc/html/draft-ietf-suit-manifest-34#name-integrated-payloads), where payloads are an additional item in the SUIT envelope.

The integrated payload is stored in the envelope using the URI as a key, as suggested for a network operator in the [SUIT manifest draft](https://datatracker.ietf.org/doc/html/draft-ietf-suit-manifest-34#name-integrated-payload-template). The implementation required changes to a bunch of function signatures because earlier there was no way to access any other envelope elements besides the manifest itself while the manifest is being parsed. I extended these function signatures to additionally take a reference to an `Envelope`.

Logic changes are generally feature gated behind the new feature `integrated-payload`, but the changes to the function signatures take effect regardless of the feature being activated. It would be an option to wrap the additional function parameter in an `Option`. I am unsure about whether this would be an improvement over my current implementation.

I'm marking this as a draft for now because of the API changes, I would appreciate any feedback.